### PR TITLE
Added options for codecs, filters and formats

### DIFF
--- a/.github/workflows/on_pull_request_merge.yaml
+++ b/.github/workflows/on_pull_request_merge.yaml
@@ -20,3 +20,12 @@ jobs:
         run: |
           sudo apt -y update && sudo apt -y install nasm
           make test
+      - name: Generate coverage report
+        run: make coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./build/coverage.out
+          flags: unittests
+          name: codecov-go-${{ matrix.go-version }}
+          fail_ci_if_error: false

--- a/.github/workflows/on_pull_request_merge.yaml
+++ b/.github/workflows/on_pull_request_merge.yaml
@@ -22,9 +22,11 @@ jobs:
           make test
       - name: Generate coverage report
         run: make coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: mutablelogic/go-media
           files: ./build/coverage.out
           flags: unittests
           name: codecov-go-${{ matrix.go-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ vendor
 tmp
 .claude
 *.test
+*.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -168,30 +168,30 @@ docker-push: docker-dep
 .PHONY: test
 test: ffmpeg chromaprint test-ffmpeg test-chromaprint
 	@echo ... test pkg/file
-	@${GO} test ./pkg/file
+	@${GO} test ${ARGS} ./pkg/file
 
 .PHONY: test-chromaprint
 test-chromaprint:
 	@echo ... test pkg/chromaprint
-	@${CGO_ENV} ${GO} test ./pkg/segmenter
-	@${CGO_ENV} ${GO} test ./pkg/chromaprint
+	@${CGO_ENV} ${GO} test ${ARGS} ./pkg/segmenter
+	@${CGO_ENV} ${GO} test ${ARGS} ./pkg/chromaprint
 
 .PHONY: test-sys
 test-sys: go-dep go-tidy
 	@echo Test
 	@echo ... test sys/${SYS_VERSION}
-	@${CGO_ENV} ${GO} test ./sys/${SYS_VERSION}
+	@${CGO_ENV} ${GO} test ${ARGS} ./sys/${SYS_VERSION}
 
 .PHONY: test-ffmpeg
 test-ffmpeg: test-sys
 	@echo Test
 	@echo ... test pkg/ffmpeg/...
-	@${CGO_ENV} ${GO} test ./pkg/ffmpeg/...
+	@${CGO_ENV} ${GO} test ${ARGS} ./pkg/ffmpeg/...
 
 .PHONY: coverage
 coverage: ffmpeg chromaprint mkdir
 	@echo "Running tests with coverage..."
-	@${CGO_ENV} ${GO} test -coverprofile=${BUILD_DIR}/coverage.out -covermode=atomic ./sys/${SYS_VERSION} ./pkg/...
+	@${CGO_ENV} ${GO} test ${ARGS} -coverprofile=${BUILD_DIR}/coverage.out -covermode=atomic ./sys/${SYS_VERSION} ./pkg/...
 	@${GO} tool cover -func=${BUILD_DIR}/coverage.out | tail -1
 	@echo "Checking coverage threshold..."
 	@COVERAGE=$$(${GO} tool cover -func=${BUILD_DIR}/coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//'); \

--- a/Makefile
+++ b/Makefile
@@ -189,27 +189,12 @@ test-ffmpeg: test-sys
 	@${CGO_ENV} ${GO} test ${ARGS} ./pkg/ffmpeg/...
 
 .PHONY: coverage
-coverage: ffmpeg chromaprint mkdir
+coverage: ffmpeg chromaprint sdl-dep mkdir
 	@echo "Running tests with coverage..."
-	@${CGO_ENV} ${GO} test ${ARGS} -coverprofile=${BUILD_DIR}/coverage.out -covermode=atomic ./sys/${SYS_VERSION} ./pkg/...
+	@${CGO_ENV} ${GO} test ${ARGS} ${BUILD_FLAGS} -coverprofile=${BUILD_DIR}/coverage.out -covermode=atomic ./sys/${SYS_VERSION} ./pkg/...
 	@${GO} tool cover -func=${BUILD_DIR}/coverage.out | tail -1
-	@echo "Checking coverage threshold..."
-	@COVERAGE=$$(${GO} tool cover -func=${BUILD_DIR}/coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//'); \
-	THRESHOLD=50; \
-	if [ "$$(echo "$$COVERAGE < $$THRESHOLD" | bc)" -eq 1 ]; then \
-		echo "❌ Coverage $$COVERAGE% is below threshold $$THRESHOLD%"; \
-		exit 1; \
-	else \
-		echo "✅ Coverage $$COVERAGE% meets threshold $$THRESHOLD%"; \
-	fi
-	@echo "Generating HTML coverage report..."
 	@${GO} tool cover -html=${BUILD_DIR}/coverage.out -o ${BUILD_DIR}/coverage.html
 	@echo "Coverage report: ${BUILD_DIR}/coverage.html"
-
-.PHONY: coverage-report
-coverage-report: coverage
-	@echo "Detailed coverage report:"
-	@${GO} tool cover -func=${BUILD_DIR}/coverage.out
 
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,29 @@ test-ffmpeg: test-sys
 	@echo ... test pkg/ffmpeg/...
 	@${CGO_ENV} ${GO} test ./pkg/ffmpeg/...
 
+.PHONY: coverage
+coverage: ffmpeg chromaprint mkdir
+	@echo "Running tests with coverage..."
+	@${CGO_ENV} ${GO} test -coverprofile=${BUILD_DIR}/coverage.out -covermode=atomic ./sys/${SYS_VERSION} ./pkg/...
+	@${GO} tool cover -func=${BUILD_DIR}/coverage.out | tail -1
+	@echo "Checking coverage threshold..."
+	@COVERAGE=$$(${GO} tool cover -func=${BUILD_DIR}/coverage.out | tail -1 | awk '{print $$3}' | sed 's/%//'); \
+	THRESHOLD=50; \
+	if [ "$$(echo "$$COVERAGE < $$THRESHOLD" | bc)" -eq 1 ]; then \
+		echo "❌ Coverage $$COVERAGE% is below threshold $$THRESHOLD%"; \
+		exit 1; \
+	else \
+		echo "✅ Coverage $$COVERAGE% meets threshold $$THRESHOLD%"; \
+	fi
+	@echo "Generating HTML coverage report..."
+	@${GO} tool cover -html=${BUILD_DIR}/coverage.out -o ${BUILD_DIR}/coverage.html
+	@echo "Coverage report: ${BUILD_DIR}/coverage.html"
+
+.PHONY: coverage-report
+coverage-report: coverage
+	@echo "Detailed coverage report:"
+	@${GO} tool cover -func=${BUILD_DIR}/coverage.out
+
 
 ###############################################################################
 # DEPENDENCIES, ETC

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ environment variables:
 make              # Build the gomedia command-line tool
 make test         # Run all tests
 make test-sys     # Run system/FFmpeg binding tests only
+make coverage     # Run tests with coverage report
+make coverage-html # Generate HTML coverage report
 ```
 
 To build manually:
@@ -98,6 +100,18 @@ export CGO_LDFLAGS_ALLOW="-(W|D).*"
 export CGO_LDFLAGS="-lstdc++ -Wl,-no_warn_duplicate_libraries"
 go build -o build/gomedia ./cmd/gomedia
 ```
+
+### Testing and Coverage
+
+Run tests:
+
+```bash
+make test                # Run all tests
+make coverage            # Run tests with coverage, check threshold, generate HTML report
+make coverage-report     # Show detailed per-function coverage
+```
+
+Coverage report is generated at `build/coverage.html`. Current coverage: **~57.7%**.
 
 ## Usage
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,11 @@ coverage:
         target: 60%
         threshold: 5%
 
+comment:
+  layout: "header, diff, files"
+  require_changes: true
+
 ignore:
   - "**/*_test.go"
-  - "**/schema/*.go"
   - "pkg/version/*.go"
   - "cmd/**/*.go"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 5%
+
+ignore:
+  - "**/*_test.go"
+  - "**/schema/*.go"
+  - "pkg/version/*.go"
+  - "cmd/**/*.go"

--- a/pkg/ffmpeg/task/probe.go
+++ b/pkg/ffmpeg/task/probe.go
@@ -23,7 +23,7 @@ func (m *Manager) Probe(_ context.Context, req *schema.ProbeRequest) (*schema.Pr
 		reader, err = ffmpeg.NewReader(req.Reader, opt)
 	} else {
 		// Parse URL to support device:// scheme
-		reader, err = OpenReaderFromURL(req.Input)
+		reader, err = OpenReaderFromURL(req.Input, opt)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/ffmpeg/task/url.go
+++ b/pkg/ffmpeg/task/url.go
@@ -91,8 +91,9 @@ func ParseMediaURL(input string) (*ParsedURL, error) {
 }
 
 // OpenReader creates a Reader from a parsed media URL
-func OpenReader(parsed *ParsedURL) (*ffmpeg.Reader, error) {
-	var opts []ffmpeg.Opt
+func OpenReader(parsed *ParsedURL, extraOpts ...ffmpeg.Opt) (*ffmpeg.Reader, error) {
+	// Start with extra options passed by caller
+	opts := append([]ffmpeg.Opt{}, extraOpts...)
 
 	// For device URLs, specify the format and options
 	if parsed.IsDevice {
@@ -146,10 +147,10 @@ func OpenReader(parsed *ParsedURL) (*ffmpeg.Reader, error) {
 }
 
 // OpenReaderFromURL is a convenience function that parses and opens in one call
-func OpenReaderFromURL(input string) (*ffmpeg.Reader, error) {
+func OpenReaderFromURL(input string, opts ...ffmpeg.Opt) (*ffmpeg.Reader, error) {
 	parsed, err := ParseMediaURL(input)
 	if err != nil {
 		return nil, err
 	}
-	return OpenReader(parsed)
+	return OpenReader(parsed, opts...)
 }

--- a/pkg/ffmpeg/writer_test.go
+++ b/pkg/ffmpeg/writer_test.go
@@ -1561,6 +1561,10 @@ func Test_encode_multiple_streams_interleaved_mp4(t *testing.T) {
 // Test demonstrating why interleaving matters: this shows the difference between
 // sending all video first vs properly interleaved.
 func Test_encode_interleaving_comparison(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping slow encoding test in short mode")
+	}
+
 	assert := assert.New(t)
 
 	// Test 1: All video first, then all audio (not optimal)
@@ -1606,8 +1610,8 @@ func createVideoAudioFile(t *testing.T, outputFile string, interleave bool) {
 	(*ff.AVFrame)(audioFrame).SetNumSamples(1024)
 	audioFrame.AllocateBuffers()
 
-	numVideoFrames := 30
-	numAudioFrames := 34 // ~1.2 seconds of audio at 44.1kHz
+	numVideoFrames := 5 // Reduced from 30 to 5 for faster testing
+	numAudioFrames := 6 // Reduced from 34 to 6 for faster testing
 
 	if interleave {
 		// Properly interleaved: alternate based on timestamps

--- a/pkg/sdl/audio.go
+++ b/pkg/sdl/audio.go
@@ -1,3 +1,5 @@
+//go:build sdl2
+
 package sdl
 
 import (

--- a/pkg/sdl/context.go
+++ b/pkg/sdl/context.go
@@ -1,3 +1,5 @@
+//go:build sdl2
+
 package sdl
 
 import (

--- a/pkg/sdl/playback.go
+++ b/pkg/sdl/playback.go
@@ -1,3 +1,5 @@
+//go:build sdl2
+
 package sdl
 
 import (

--- a/pkg/sdl/player.go
+++ b/pkg/sdl/player.go
@@ -1,3 +1,5 @@
+//go:build sdl2
+
 package sdl
 
 import (

--- a/pkg/sdl/window.go
+++ b/pkg/sdl/window.go
@@ -1,3 +1,5 @@
+//go:build sdl2
+
 package sdl
 
 import (

--- a/sys/ffmpeg80/avcodec_codec.go
+++ b/sys/ffmpeg80/avcodec_codec.go
@@ -146,6 +146,8 @@ func (ctx *AVCodec) MarshalJSON() ([]byte, error) {
 		Name           string            `json:"name,omitempty"`
 		LongName       string            `json:"long_name,omitempty"`
 		ID             AVCodecID         `json:"id,omitempty"`
+		IsEncoder      bool              `json:"is_encoder"`
+		IsDecoder      bool              `json:"is_decoder"`
 		Capabilities   AVCodecCap        `json:"capabilities,omitempty"`
 		Framerates     []AVRational      `json:"supported_framerates,omitempty"`
 		SampleFormats  []AVSampleFormat  `json:"sample_formats,omitempty"`
@@ -159,6 +161,8 @@ func (ctx *AVCodec) MarshalJSON() ([]byte, error) {
 		LongName:       C.GoString(ctx.long_name),
 		Type:           AVMediaType(ctx._type),
 		ID:             AVCodecID(ctx.id),
+		IsEncoder:      ctx.IsEncoder(),
+		IsDecoder:      ctx.IsDecoder(),
 		Capabilities:   AVCodecCap(ctx.capabilities),
 		Framerates:     ctx.SupportedFramerates(),
 		SampleFormats:  ctx.SampleFormats(),
@@ -373,6 +377,18 @@ func (c *AVCodec) ChannelLayouts() []AVChannelLayout {
 		ptr += unsafe.Sizeof(AVChannelLayout{})
 	}
 	return result
+}
+
+func (c *AVCodec) IsEncoder() bool {
+	return C.av_codec_is_encoder((*C.struct_AVCodec)(c)) != 0
+}
+
+func (c *AVCodec) IsDecoder() bool {
+	return C.av_codec_is_decoder((*C.struct_AVCodec)(c)) != 0
+}
+
+func (c *AVCodec) PrivClass() *AVClass {
+	return (*AVClass)(c.priv_class)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/sys/ffmpeg80/avfilter_filter.go
+++ b/sys/ffmpeg80/avfilter_filter.go
@@ -69,6 +69,10 @@ func (c *AVFilter) NumOutputs() uint {
 	return AVFilter_outputs(c)
 }
 
+func (c *AVFilter) PrivClass() *AVClass {
+	return (*AVClass)(c.priv_class)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
 

--- a/sys/ffmpeg80/avfilter_filter_test.go
+++ b/sys/ffmpeg80/avfilter_filter_test.go
@@ -106,3 +106,90 @@ func Test_avfilter_flag_001(t *testing.T) {
 	flag = ff.AVFILTER_FLAG_SUPPORT_TIMELINE
 	assert.Contains(t, flag.String(), "TIMELINE")
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST PrivClass on AVFilter
+
+func Test_avfilter_filter_priv_class(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test filter with priv_class
+	filter := ff.AVFilter_get_by_name("scale")
+	assert.NotNil(filter, "scale filter should exist")
+
+	class := filter.PrivClass()
+	if class == nil {
+		t.Skip("scale filter has no priv_class")
+	}
+
+	assert.NotNil(class, "scale filter should have priv_class")
+
+	// The class should have a valid name
+	className := class.Name()
+	assert.NotEmpty(className, "AVClass should have a name")
+	t.Logf("scale filter priv_class name: %s", className)
+}
+
+func Test_avfilter_filter_priv_class_options(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test that we can enumerate options via PrivClass
+	filter := ff.AVFilter_get_by_name("scale")
+	assert.NotNil(filter, "scale filter should exist")
+
+	class := filter.PrivClass()
+	if class == nil {
+		t.Skip("scale filter has no priv_class")
+	}
+
+	// Use FAKE_OBJ trick to enumerate options
+	options := ff.AVUtil_opt_list_from_class(class)
+	assert.NotEmpty(options, "scale filter should have options")
+
+	t.Logf("Found %d options for scale filter via PrivClass", len(options))
+
+	// Look for known scale options
+	foundWidth := false
+	foundHeight := false
+	for _, opt := range options {
+		switch opt.Name() {
+		case "w", "width":
+			foundWidth = true
+			t.Logf("Found width option: help=%s, type=%v", opt.Help(), opt.Type())
+		case "h", "height":
+			foundHeight = true
+			t.Logf("Found height option: help=%s, type=%v", opt.Help(), opt.Type())
+		}
+	}
+
+	assert.True(foundWidth, "Expected to find width option in scale filter")
+	assert.True(foundHeight, "Expected to find height option in scale filter")
+}
+
+func Test_avfilter_multiple_filters_priv_class(t *testing.T) {
+	// Test several different filters
+	testFilters := []string{"scale", "crop", "overlay", "pad"}
+
+	for _, filterName := range testFilters {
+		filter := ff.AVFilter_get_by_name(filterName)
+		if filter == nil {
+			t.Logf("Skipping %s: filter not found", filterName)
+			continue
+		}
+
+		class := filter.PrivClass()
+		if class == nil {
+			t.Logf("Skipping %s: no priv_class", filterName)
+			continue
+		}
+
+		options := ff.AVUtil_opt_list_from_class(class)
+		t.Logf("Filter %s: %d options via PrivClass", filterName, len(options))
+
+		// Show first few options
+		for i := 0; i < min(3, len(options)); i++ {
+			opt := options[i]
+			t.Logf("  Option: %s (%v)", opt.Name(), opt.Type())
+		}
+	}
+}

--- a/sys/ffmpeg80/avformat_input.go
+++ b/sys/ffmpeg80/avformat_input.go
@@ -82,3 +82,7 @@ func (ctx *AVInputFormat) MimeTypes() string {
 func (ctx *AVInputFormat) Extensions() string {
 	return C.GoString(ctx.extensions)
 }
+
+func (ctx *AVInputFormat) PrivClass() *AVClass {
+	return (*AVClass)(ctx.priv_class)
+}

--- a/sys/ffmpeg80/avformat_output.go
+++ b/sys/ffmpeg80/avformat_output.go
@@ -86,6 +86,10 @@ func (ctx *AVOutputFormat) SubtitleCodec() AVCodecID {
 	return AVCodecID(ctx.subtitle_codec)
 }
 
+func (ctx *AVOutputFormat) PrivClass() *AVClass {
+	return (*AVClass)(ctx.priv_class)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // BINDINGS
 

--- a/sys/ffmpeg80/avutil_opt.go
+++ b/sys/ffmpeg80/avutil_opt.go
@@ -28,6 +28,14 @@ type (
 )
 
 ////////////////////////////////////////////////////////////////////////////////
+// METHODS - AVClass
+
+// Name returns the class name.
+func (c *AVClass) Name() string {
+	return C.GoString((*C.struct_AVClass)(unsafe.Pointer(c)).class_name)
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // METHODS - AVOption
 
 // Name returns the option name.

--- a/sys/ffmpeg80/avutil_opt.go
+++ b/sys/ffmpeg80/avutil_opt.go
@@ -65,7 +65,7 @@ func (o *AVOption) Max() float64 {
 }
 
 // DefaultVal returns the default value as an interface{}, type depends on the option type.
-// Returns nil for const options or if no default is set.
+// For const options, returns their constant value; returns nil if no default is set or the type is unsupported.
 func (o *AVOption) DefaultVal() interface{} {
 	opt := (*C.struct_AVOption)(unsafe.Pointer(o))
 	switch o.Type() {

--- a/sys/ffmpeg80/avutil_opt.go
+++ b/sys/ffmpeg80/avutil_opt.go
@@ -1,0 +1,731 @@
+package ffmpeg
+
+import (
+	"encoding/json"
+	"math"
+	"unsafe"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libavutil
+#include <libavutil/avutil.h>
+#include <libavutil/opt.h>
+#include <stdlib.h>
+*/
+import "C"
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type (
+	AVOption       C.struct_AVOption
+	AVOptionType   C.enum_AVOptionType
+	AVOptionRanges C.struct_AVOptionRanges
+	AVOptionRange  C.struct_AVOptionRange
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// METHODS - AVOption
+
+// Name returns the option name.
+func (o *AVOption) Name() string {
+	return C.GoString((*C.struct_AVOption)(unsafe.Pointer(o)).name)
+}
+
+// Help returns the short English help text for the option.
+func (o *AVOption) Help() string {
+	help := (*C.struct_AVOption)(unsafe.Pointer(o)).help
+	if help == nil {
+		return ""
+	}
+	return C.GoString(help)
+}
+
+// Type returns the option type.
+func (o *AVOption) Type() AVOptionType {
+	return AVOptionType((*C.struct_AVOption)(unsafe.Pointer(o))._type)
+}
+
+// Offset returns the offset of the option in the context structure.
+func (o *AVOption) Offset() int {
+	return int((*C.struct_AVOption)(unsafe.Pointer(o)).offset)
+}
+
+// Min returns the minimum valid value for numeric options.
+func (o *AVOption) Min() float64 {
+	return float64((*C.struct_AVOption)(unsafe.Pointer(o)).min)
+}
+
+// Max returns the maximum valid value for numeric options.
+func (o *AVOption) Max() float64 {
+	return float64((*C.struct_AVOption)(unsafe.Pointer(o)).max)
+}
+
+// DefaultVal returns the default value as an interface{}, type depends on the option type.
+// Returns nil for const options or if no default is set.
+func (o *AVOption) DefaultVal() interface{} {
+	opt := (*C.struct_AVOption)(unsafe.Pointer(o))
+	switch o.Type() {
+	case AV_OPT_TYPE_INT, AV_OPT_TYPE_INT64, AV_OPT_TYPE_UINT64:
+		// Cast the union bytes to int64
+		return int64(*(*C.int64_t)(unsafe.Pointer(&opt.default_val)))
+	case AV_OPT_TYPE_UINT:
+		// Cast the union bytes to uint
+		return uint(*(*C.int64_t)(unsafe.Pointer(&opt.default_val)))
+	case AV_OPT_TYPE_DOUBLE, AV_OPT_TYPE_DURATION:
+		// Cast the union bytes to double
+		return float64(*(*C.double)(unsafe.Pointer(&opt.default_val)))
+	case AV_OPT_TYPE_FLOAT:
+		// Cast the union bytes to double (FFmpeg stores float as double in union)
+		return float32(*(*C.double)(unsafe.Pointer(&opt.default_val)))
+	case AV_OPT_TYPE_STRING:
+		// Cast the union bytes to string pointer
+		strPtr := *(**C.char)(unsafe.Pointer(&opt.default_val))
+		if strPtr != nil {
+			return C.GoString(strPtr)
+		}
+		return nil
+	case AV_OPT_TYPE_RATIONAL, AV_OPT_TYPE_VIDEO_RATE:
+		// Cast the union bytes to AVRational
+		q := *(*C.AVRational)(unsafe.Pointer(&opt.default_val))
+		return AVRational(q)
+	case AV_OPT_TYPE_FLAGS:
+		// Cast the union bytes to uint
+		return uint(*(*C.int64_t)(unsafe.Pointer(&opt.default_val)))
+	case AV_OPT_TYPE_BOOL:
+		// Cast the union bytes to int64 and check if non-zero
+		return *(*C.int64_t)(unsafe.Pointer(&opt.default_val)) != 0
+	case AV_OPT_TYPE_CONST:
+		// For const, the default_val contains the value of the constant
+		return int64(*(*C.int64_t)(unsafe.Pointer(&opt.default_val)))
+	default:
+		return nil
+	}
+}
+
+// Flags returns the option flags (AV_OPT_FLAG_*).
+func (o *AVOption) Flags() int {
+	return int((*C.struct_AVOption)(unsafe.Pointer(o)).flags)
+}
+
+// Unit returns the logical unit to which the option belongs.
+// For const options, this is the name of the option they provide values for.
+func (o *AVOption) Unit() string {
+	unit := (*C.struct_AVOption)(unsafe.Pointer(o)).unit
+	if unit == nil {
+		return ""
+	}
+	return C.GoString(unit)
+}
+
+// MarshalJSON implements json.Marshaler for AVOption.
+func (o *AVOption) MarshalJSON() ([]byte, error) {
+	type optJSON struct {
+		Name    string       `json:"name"`
+		Help    string       `json:"help,omitempty"`
+		Type    AVOptionType `json:"type"`
+		Default interface{}  `json:"default,omitempty"`
+		Min     *float64     `json:"min,omitempty"`
+		Max     *float64     `json:"max,omitempty"`
+		Unit    string       `json:"unit,omitempty"`
+	}
+
+	result := optJSON{
+		Name: o.Name(),
+		Help: o.Help(),
+		Type: o.Type(),
+		Unit: o.Unit(),
+	}
+
+	// Handle default value, checking for NaN in float types
+	defVal := o.DefaultVal()
+	if defVal != nil {
+		switch v := defVal.(type) {
+		case float64:
+			if !math.IsNaN(v) && !math.IsInf(v, 0) {
+				result.Default = v
+			}
+		default:
+			result.Default = v
+		}
+	}
+
+	// Only include min/max for numeric types, and skip NaN values
+	switch o.Type() {
+	case AV_OPT_TYPE_INT, AV_OPT_TYPE_INT64, AV_OPT_TYPE_UINT, AV_OPT_TYPE_UINT64,
+		AV_OPT_TYPE_DOUBLE, AV_OPT_TYPE_FLOAT, AV_OPT_TYPE_DURATION:
+		min := o.Min()
+		max := o.Max()
+		if !math.IsNaN(min) && !math.IsInf(min, 0) {
+			result.Min = &min
+		}
+		if !math.IsNaN(max) && !math.IsInf(max, 0) {
+			result.Max = &max
+		}
+	}
+
+	return json.Marshal(result)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CONSTANTS - AVOptionType
+
+const (
+	AV_OPT_TYPE_FLAGS      AVOptionType = C.AV_OPT_TYPE_FLAGS // Bitmask flags option (unsigned int)
+	AV_OPT_TYPE_INT        AVOptionType = C.AV_OPT_TYPE_INT
+	AV_OPT_TYPE_INT64      AVOptionType = C.AV_OPT_TYPE_INT64
+	AV_OPT_TYPE_UINT       AVOptionType = C.AV_OPT_TYPE_UINT
+	AV_OPT_TYPE_UINT64     AVOptionType = C.AV_OPT_TYPE_UINT64
+	AV_OPT_TYPE_DOUBLE     AVOptionType = C.AV_OPT_TYPE_DOUBLE
+	AV_OPT_TYPE_FLOAT      AVOptionType = C.AV_OPT_TYPE_FLOAT
+	AV_OPT_TYPE_STRING     AVOptionType = C.AV_OPT_TYPE_STRING
+	AV_OPT_TYPE_RATIONAL   AVOptionType = C.AV_OPT_TYPE_RATIONAL
+	AV_OPT_TYPE_BINARY     AVOptionType = C.AV_OPT_TYPE_BINARY
+	AV_OPT_TYPE_DICT       AVOptionType = C.AV_OPT_TYPE_DICT
+	AV_OPT_TYPE_CONST      AVOptionType = C.AV_OPT_TYPE_CONST // Named constant used to define possible values for FLAGS and other options
+	AV_OPT_TYPE_IMAGE_SIZE AVOptionType = C.AV_OPT_TYPE_IMAGE_SIZE
+	AV_OPT_TYPE_PIXEL_FMT  AVOptionType = C.AV_OPT_TYPE_PIXEL_FMT
+	AV_OPT_TYPE_SAMPLE_FMT AVOptionType = C.AV_OPT_TYPE_SAMPLE_FMT
+	AV_OPT_TYPE_VIDEO_RATE AVOptionType = C.AV_OPT_TYPE_VIDEO_RATE
+	AV_OPT_TYPE_DURATION   AVOptionType = C.AV_OPT_TYPE_DURATION
+	AV_OPT_TYPE_COLOR      AVOptionType = C.AV_OPT_TYPE_COLOR
+	AV_OPT_TYPE_BOOL       AVOptionType = C.AV_OPT_TYPE_BOOL
+	AV_OPT_TYPE_CHLAYOUT   AVOptionType = C.AV_OPT_TYPE_CHLAYOUT
+	AV_OPT_TYPE_FLAG_ARRAY AVOptionType = C.AV_OPT_TYPE_FLAG_ARRAY
+)
+
+// MarshalJSON implements json.Marshaler for AVOptionType.
+func (t AVOptionType) MarshalJSON() ([]byte, error) {
+	var s string
+	switch t {
+	case AV_OPT_TYPE_FLAGS:
+		s = "flags"
+	case AV_OPT_TYPE_INT:
+		s = "int"
+	case AV_OPT_TYPE_INT64:
+		s = "int64"
+	case AV_OPT_TYPE_UINT:
+		s = "uint"
+	case AV_OPT_TYPE_UINT64:
+		s = "uint64"
+	case AV_OPT_TYPE_DOUBLE:
+		s = "double"
+	case AV_OPT_TYPE_FLOAT:
+		s = "float"
+	case AV_OPT_TYPE_STRING:
+		s = "string"
+	case AV_OPT_TYPE_RATIONAL:
+		s = "rational"
+	case AV_OPT_TYPE_BINARY:
+		s = "binary"
+	case AV_OPT_TYPE_DICT:
+		s = "dict"
+	case AV_OPT_TYPE_CONST:
+		s = "const"
+	case AV_OPT_TYPE_IMAGE_SIZE:
+		s = "image_size"
+	case AV_OPT_TYPE_PIXEL_FMT:
+		s = "pixel_fmt"
+	case AV_OPT_TYPE_SAMPLE_FMT:
+		s = "sample_fmt"
+	case AV_OPT_TYPE_VIDEO_RATE:
+		s = "video_rate"
+	case AV_OPT_TYPE_DURATION:
+		s = "duration"
+	case AV_OPT_TYPE_COLOR:
+		s = "color"
+	case AV_OPT_TYPE_BOOL:
+		s = "bool"
+	case AV_OPT_TYPE_CHLAYOUT:
+		s = "chlayout"
+	case AV_OPT_TYPE_FLAG_ARRAY:
+		s = "flag_array"
+	default:
+		s = "unknown"
+	}
+	return json.Marshal(s)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// CONSTANTS - Search flags
+
+const (
+	// Search in possible children of the given object first.
+	AV_OPT_SEARCH_CHILDREN = C.AV_OPT_SEARCH_CHILDREN
+
+	// Search fake options (option names used in documented examples).
+	AV_OPT_SEARCH_FAKE_OBJ = C.AV_OPT_SEARCH_FAKE_OBJ
+
+	// Allow to pass options as flags instead of values.
+	AV_OPT_FLAG_IMPLICIT_KEY = C.AV_OPT_FLAG_IMPLICIT_KEY
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// CONSTANTS - Serialization flags
+
+const (
+	// Serialize options that are not set to default values.
+	AV_OPT_SERIALIZE_SKIP_DEFAULTS = C.AV_OPT_SERIALIZE_SKIP_DEFAULTS
+
+	// Serialize options that are exactly equal to default values.
+	AV_OPT_SERIALIZE_OPT_FLAGS_EXACT = C.AV_OPT_SERIALIZE_OPT_FLAGS_EXACT
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_show2
+
+// AVUtil_opt_show2 shows the obj options. Returns 0 on success, a negative value on error.
+func AVUtil_opt_show2(obj unsafe.Pointer, av_log_obj unsafe.Pointer, req_flags, rej_flags int) error {
+	if ret := AVError(C.av_opt_show2(obj, av_log_obj, C.int(req_flags), C.int(rej_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_defaults
+
+// AVUtil_opt_set_defaults sets the values of all AVOption fields to their default values.
+func AVUtil_opt_set_defaults(obj unsafe.Pointer) {
+	C.av_opt_set_defaults(obj)
+}
+
+// AVUtil_opt_set_defaults2 sets the values of all AVOption fields to their default values.
+// Only options which are not set to default values will be set.
+func AVUtil_opt_set_defaults2(obj unsafe.Pointer, mask, flags int) {
+	C.av_opt_set_defaults2(obj, C.int(mask), C.int(flags))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set (string)
+
+// AVUtil_opt_set sets a string option value.
+func AVUtil_opt_set(obj unsafe.Pointer, name, value string, search_flags int) error {
+	cName := C.CString(name)
+	cValue := C.CString(value)
+	defer C.free(unsafe.Pointer(cName))
+	defer C.free(unsafe.Pointer(cValue))
+
+	if ret := AVError(C.av_opt_set(obj, cName, cValue, C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_int
+
+// AVUtil_opt_set_int sets an integer option value.
+func AVUtil_opt_set_int(obj unsafe.Pointer, name string, value int64, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_int(obj, cName, C.int64_t(value), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_double
+
+// AVUtil_opt_set_double sets a double option value.
+func AVUtil_opt_set_double(obj unsafe.Pointer, name string, value float64, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_double(obj, cName, C.double(value), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_q
+
+// AVUtil_opt_set_q sets a rational option value.
+func AVUtil_opt_set_q(obj unsafe.Pointer, name string, value AVRational, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_q(obj, cName, (C.AVRational)(value), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_bin
+
+// AVUtil_opt_set_bin sets a binary option value.
+func AVUtil_opt_set_bin(obj unsafe.Pointer, name string, value []byte, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var ptr unsafe.Pointer
+	if len(value) > 0 {
+		ptr = unsafe.Pointer(&value[0])
+	}
+
+	if ret := AVError(C.av_opt_set_bin(obj, cName, (*C.uint8_t)(ptr), C.int(len(value)), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_image_size
+
+// AVUtil_opt_set_image_size sets an image size option value.
+func AVUtil_opt_set_image_size(obj unsafe.Pointer, name string, width, height, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_image_size(obj, cName, C.int(width), C.int(height), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_pixel_fmt
+
+// AVUtil_opt_set_pixel_fmt sets a pixel format option value.
+func AVUtil_opt_set_pixel_fmt(obj unsafe.Pointer, name string, fmt AVPixelFormat, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_pixel_fmt(obj, cName, (C.enum_AVPixelFormat)(fmt), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_sample_fmt
+
+// AVUtil_opt_set_sample_fmt sets a sample format option value.
+func AVUtil_opt_set_sample_fmt(obj unsafe.Pointer, name string, fmt AVSampleFormat, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_sample_fmt(obj, cName, (C.enum_AVSampleFormat)(fmt), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_video_rate
+
+// AVUtil_opt_set_video_rate sets a video rate option value.
+func AVUtil_opt_set_video_rate(obj unsafe.Pointer, name string, rate AVRational, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_video_rate(obj, cName, (C.AVRational)(rate), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_set_channel_layout
+
+// AVUtil_opt_set_channel_layout sets a channel layout option value.
+func AVUtil_opt_set_channel_layout(obj unsafe.Pointer, name string, layout *AVChannelLayout, search_flags int) error {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	if ret := AVError(C.av_opt_set_chlayout(obj, cName, (*C.AVChannelLayout)(unsafe.Pointer(layout)), C.int(search_flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get (string)
+
+// AVUtil_opt_get gets a string option value.
+func AVUtil_opt_get(obj unsafe.Pointer, name string, search_flags int) (string, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cValue *C.uint8_t
+	if ret := AVError(C.av_opt_get(obj, cName, C.int(search_flags), &cValue)); ret != 0 {
+		return "", ret
+	}
+	defer C.av_free(unsafe.Pointer(cValue))
+
+	return C.GoString((*C.char)(unsafe.Pointer(cValue))), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_int
+
+// AVUtil_opt_get_int gets an integer option value.
+func AVUtil_opt_get_int(obj unsafe.Pointer, name string, search_flags int) (int64, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var value C.int64_t
+	if ret := AVError(C.av_opt_get_int(obj, cName, C.int(search_flags), &value)); ret != 0 {
+		return 0, ret
+	}
+	return int64(value), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_double
+
+// AVUtil_opt_get_double gets a double option value.
+func AVUtil_opt_get_double(obj unsafe.Pointer, name string, search_flags int) (float64, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var value C.double
+	if ret := AVError(C.av_opt_get_double(obj, cName, C.int(search_flags), &value)); ret != 0 {
+		return 0, ret
+	}
+	return float64(value), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_q
+
+// AVUtil_opt_get_q gets a rational option value.
+func AVUtil_opt_get_q(obj unsafe.Pointer, name string, search_flags int) (AVRational, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var value C.AVRational
+	if ret := AVError(C.av_opt_get_q(obj, cName, C.int(search_flags), &value)); ret != 0 {
+		return AVRational{}, ret
+	}
+	return AVRational(value), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_image_size
+
+// AVUtil_opt_get_image_size gets an image size option value.
+func AVUtil_opt_get_image_size(obj unsafe.Pointer, name string, search_flags int) (int, int, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var width, height C.int
+	if ret := AVError(C.av_opt_get_image_size(obj, cName, C.int(search_flags), &width, &height)); ret != 0 {
+		return 0, 0, ret
+	}
+	return int(width), int(height), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_pixel_fmt
+
+// AVUtil_opt_get_pixel_fmt gets a pixel format option value.
+func AVUtil_opt_get_pixel_fmt(obj unsafe.Pointer, name string, search_flags int) (AVPixelFormat, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var fmt C.enum_AVPixelFormat
+	if ret := AVError(C.av_opt_get_pixel_fmt(obj, cName, C.int(search_flags), &fmt)); ret != 0 {
+		return AV_PIX_FMT_NONE, ret
+	}
+	return AVPixelFormat(fmt), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_sample_fmt
+
+// AVUtil_opt_get_sample_fmt gets a sample format option value.
+func AVUtil_opt_get_sample_fmt(obj unsafe.Pointer, name string, search_flags int) (AVSampleFormat, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var fmt C.enum_AVSampleFormat
+	if ret := AVError(C.av_opt_get_sample_fmt(obj, cName, C.int(search_flags), &fmt)); ret != 0 {
+		return AV_SAMPLE_FMT_NONE, ret
+	}
+	return AVSampleFormat(fmt), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_video_rate
+
+// AVUtil_opt_get_video_rate gets a video rate option value.
+func AVUtil_opt_get_video_rate(obj unsafe.Pointer, name string, search_flags int) (AVRational, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var rate C.AVRational
+	if ret := AVError(C.av_opt_get_video_rate(obj, cName, C.int(search_flags), &rate)); ret != 0 {
+		return AVRational{}, ret
+	}
+	return AVRational(rate), nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_get_channel_layout
+
+// AVUtil_opt_get_channel_layout gets a channel layout option value.
+func AVUtil_opt_get_channel_layout(obj unsafe.Pointer, name string, search_flags int) (*AVChannelLayout, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	layout := &AVChannelLayout{}
+	if ret := AVError(C.av_opt_get_chlayout(obj, cName, C.int(search_flags), (*C.AVChannelLayout)(unsafe.Pointer(layout)))); ret != 0 {
+		return nil, ret
+	}
+	return layout, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_find
+
+// AVUtil_opt_find looks for an option in an object.
+// Returns a pointer to the option found, or nil if no option was found.
+func AVUtil_opt_find(obj unsafe.Pointer, name string, unit string, opt_flags, search_flags int) *AVOption {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cUnit *C.char
+	if unit != "" {
+		cUnit = C.CString(unit)
+		defer C.free(unsafe.Pointer(cUnit))
+	}
+
+	return (*AVOption)(C.av_opt_find(obj, cName, cUnit, C.int(opt_flags), C.int(search_flags)))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_find2
+
+// AVUtil_opt_find2 looks for an option in an object.
+// Returns a pointer to the option found, or nil if no option was found.
+// target_obj is set to the object where the option was found.
+func AVUtil_opt_find2(obj unsafe.Pointer, name string, unit string, opt_flags, search_flags int) (*AVOption, unsafe.Pointer) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cUnit *C.char
+	if unit != "" {
+		cUnit = C.CString(unit)
+		defer C.free(unsafe.Pointer(cUnit))
+	}
+
+	var targetObj unsafe.Pointer
+	opt := (*AVOption)(C.av_opt_find2(obj, cName, cUnit, C.int(opt_flags), C.int(search_flags), &targetObj))
+	return opt, targetObj
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_copy
+
+// AVUtil_opt_copy copies options from src to dst.
+func AVUtil_opt_copy(dst, src unsafe.Pointer) error {
+	if ret := AVError(C.av_opt_copy(dst, src)); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_query_ranges
+
+// AVUtil_opt_query_ranges gets a list of allowed ranges for the given option.
+// The returned ranges must be freed with AVUtil_opt_freep_ranges.
+func AVUtil_opt_query_ranges(ranges **AVOptionRanges, obj unsafe.Pointer, key string, flags int) error {
+	cKey := C.CString(key)
+	defer C.free(unsafe.Pointer(cKey))
+
+	if ret := AVError(C.av_opt_query_ranges((**C.struct_AVOptionRanges)(unsafe.Pointer(ranges)), obj, cKey, C.int(flags))); ret != 0 {
+		return ret
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_freep_ranges
+
+// AVUtil_opt_freep_ranges frees an AVOptionRanges struct and set it to nil.
+func AVUtil_opt_freep_ranges(ranges **AVOptionRanges) {
+	C.av_opt_freep_ranges((**C.struct_AVOptionRanges)(unsafe.Pointer(ranges)))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_is_set_to_default
+
+// AVUtil_opt_is_set_to_default checks if given option is set to its default value.
+// Returns 1 if set to default, 0 if not default, negative on error.
+func AVUtil_opt_is_set_to_default(obj unsafe.Pointer, opt *AVOption) int {
+	return int(C.av_opt_is_set_to_default(obj, (*C.struct_AVOption)(unsafe.Pointer(opt))))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_is_set_to_default_by_name
+
+// AVUtil_opt_is_set_to_default_by_name checks if given option is set to its default value.
+// Returns 1 if set to default, 0 if not default, negative on error.
+func AVUtil_opt_is_set_to_default_by_name(obj unsafe.Pointer, name string, search_flags int) int {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	return int(C.av_opt_is_set_to_default_by_name(obj, cName, C.int(search_flags)))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_next
+
+// AVUtil_opt_next iterates over AVOptions-enabled objects.
+// Pass nil for prev to get the first option, then pass the returned option to get the next one.
+// Returns nil when there are no more options.
+func AVUtil_opt_next(obj unsafe.Pointer, prev *AVOption) *AVOption {
+	return (*AVOption)(C.av_opt_next(obj, (*C.struct_AVOption)(unsafe.Pointer(prev))))
+}
+
+// AVUtil_opt_list returns all options for an object as a slice.
+// This is a convenience wrapper around AVUtil_opt_next.
+func AVUtil_opt_list(obj unsafe.Pointer) []*AVOption {
+	var options []*AVOption
+	var prev *AVOption
+	for {
+		opt := AVUtil_opt_next(obj, prev)
+		if opt == nil {
+			break
+		}
+		options = append(options, opt)
+		prev = opt
+	}
+	return options
+}
+
+// AVUtil_opt_list_from_class returns all options for an AVClass as a slice.
+// This uses the FAKE_OBJ trick - treating the AVClass* as if it's an object
+// whose first field points to the class. This is how ffmpeg's cmdutils does it.
+func AVUtil_opt_list_from_class(class *AVClass) []*AVOption {
+	if class == nil {
+		return nil
+	}
+	// The FAKE_OBJ trick: cast AVClass* to void* and use it as an object
+	// This works because the first field of every AVClass-based object is AVClass*
+	return AVUtil_opt_list(unsafe.Pointer(&class))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FUNCTIONS - av_opt_serialize
+
+// AVUtil_opt_serialize serializes object's options to a string.
+// Returns the allocated string (must be freed with av_free), or empty string on error.
+func AVUtil_opt_serialize(obj unsafe.Pointer, opt_flags, flags int, key_val_sep, pairs_sep byte) string {
+	var cBuf *C.char
+	if ret := C.av_opt_serialize(obj, C.int(opt_flags), C.int(flags), &cBuf, C.char(key_val_sep), C.char(pairs_sep)); ret < 0 {
+		return ""
+	}
+	defer C.av_free(unsafe.Pointer(cBuf))
+
+	return C.GoString(cBuf)
+}

--- a/sys/ffmpeg80/avutil_opt_test.go
+++ b/sys/ffmpeg80/avutil_opt_test.go
@@ -1,0 +1,708 @@
+package ffmpeg_test
+
+import (
+	"encoding/json"
+	"testing"
+	"unsafe"
+
+	ff "github.com/mutablelogic/go-media/sys/ffmpeg80"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set and av_opt_get with AVCodecContext
+
+func Test_avutil_opt_001(t *testing.T) {
+	// Get H264 encoder for testing
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	// Allocate codec context
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting string option
+	if err := ff.AVUtil_opt_set(unsafe.Pointer(ctx), "preset", "fast", 0); err != nil {
+		t.Logf("Warning: could not set preset option: %v", err)
+	}
+
+	// Test getting string option (if it was set)
+	value, err := ff.AVUtil_opt_get(unsafe.Pointer(ctx), "preset", 0)
+	if err == nil {
+		t.Logf("preset = %s", value)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_int and av_opt_get_int
+
+func Test_avutil_opt_002(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting integer option (bitrate)
+	const testBitrate = 400000
+	if err := ff.AVUtil_opt_set_int(unsafe.Pointer(ctx), "b", testBitrate, 0); err != nil {
+		t.Logf("Warning: could not set bitrate option: %v", err)
+	}
+
+	// Test getting integer option
+	bitrate, err := ff.AVUtil_opt_get_int(unsafe.Pointer(ctx), "b", 0)
+	if err == nil {
+		t.Logf("bitrate = %d", bitrate)
+		if bitrate != testBitrate {
+			t.Logf("Note: bitrate value differs: expected %d, got %d", testBitrate, bitrate)
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_double and av_opt_get_double
+
+func Test_avutil_opt_003(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting double option (qcompress)
+	const testQCompress = 0.6
+	if err := ff.AVUtil_opt_set_double(unsafe.Pointer(ctx), "qcompress", testQCompress, 0); err != nil {
+		t.Logf("Warning: could not set qcompress option: %v", err)
+	}
+
+	// Test getting double option
+	qcompress, err := ff.AVUtil_opt_get_double(unsafe.Pointer(ctx), "qcompress", 0)
+	if err == nil {
+		t.Logf("qcompress = %f", qcompress)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_q and av_opt_get_q
+
+func Test_avutil_opt_004(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting rational option (time_base)
+	testTimeBase := ff.AVUtil_rational(1, 25)
+	if err := ff.AVUtil_opt_set_q(unsafe.Pointer(ctx), "time_base", testTimeBase, 0); err != nil {
+		t.Logf("Warning: could not set time_base option: %v", err)
+	}
+
+	// Test getting rational option
+	timeBase, err := ff.AVUtil_opt_get_q(unsafe.Pointer(ctx), "time_base", 0)
+	if err == nil {
+		t.Logf("time_base = %d/%d", timeBase.Num(), timeBase.Den())
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_image_size and av_opt_get_image_size
+
+func Test_avutil_opt_005(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting image size option (video_size)
+	const testWidth, testHeight = 1920, 1080
+	if err := ff.AVUtil_opt_set_image_size(unsafe.Pointer(ctx), "video_size", testWidth, testHeight, 0); err != nil {
+		t.Logf("Warning: could not set video_size option: %v", err)
+	}
+
+	// Test getting image size option
+	width, height, err := ff.AVUtil_opt_get_image_size(unsafe.Pointer(ctx), "video_size", 0)
+	if err == nil {
+		t.Logf("video_size = %dx%d", width, height)
+		if width != testWidth || height != testHeight {
+			t.Logf("Note: video_size value differs: expected %dx%d, got %dx%d", testWidth, testHeight, width, height)
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_pixel_fmt and av_opt_get_pixel_fmt
+
+func Test_avutil_opt_006(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting pixel format option
+	const testPixFmt = ff.AV_PIX_FMT_YUV420P
+	if err := ff.AVUtil_opt_set_pixel_fmt(unsafe.Pointer(ctx), "pixel_format", testPixFmt, 0); err != nil {
+		t.Logf("Warning: could not set pixel_format option: %v", err)
+	}
+
+	// Test getting pixel format option
+	pixFmt, err := ff.AVUtil_opt_get_pixel_fmt(unsafe.Pointer(ctx), "pixel_format", 0)
+	if err == nil {
+		t.Logf("pixel_format = %s", pixFmt.String())
+		if pixFmt != testPixFmt {
+			t.Logf("Note: pixel_format value differs: expected %s, got %s", testPixFmt.String(), pixFmt.String())
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_sample_fmt and av_opt_get_sample_fmt with audio encoder
+
+func Test_avutil_opt_007(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_MP2)
+	if codec == nil {
+		t.Skip("MP2 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting sample format option
+	const testSampleFmt = ff.AV_SAMPLE_FMT_FLTP
+	if err := ff.AVUtil_opt_set_sample_fmt(unsafe.Pointer(ctx), "sample_fmt", testSampleFmt, 0); err != nil {
+		t.Logf("Warning: could not set sample_fmt option: %v", err)
+	}
+
+	// Test getting sample format option
+	sampleFmt, err := ff.AVUtil_opt_get_sample_fmt(unsafe.Pointer(ctx), "sample_fmt", 0)
+	if err == nil {
+		t.Logf("sample_fmt = %s", sampleFmt.String())
+		if sampleFmt != testSampleFmt {
+			t.Logf("Note: sample_fmt value differs: expected %s, got %s", testSampleFmt.String(), sampleFmt.String())
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_video_rate and av_opt_get_video_rate
+
+func Test_avutil_opt_008(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting video rate option (framerate)
+	testRate := ff.AVUtil_rational(30, 1)
+	if err := ff.AVUtil_opt_set_video_rate(unsafe.Pointer(ctx), "r", testRate, 0); err != nil {
+		t.Logf("Warning: could not set framerate option: %v", err)
+	}
+
+	// Test getting video rate option
+	rate, err := ff.AVUtil_opt_get_video_rate(unsafe.Pointer(ctx), "r", 0)
+	if err == nil {
+		t.Logf("framerate = %d/%d (%.2f fps)", rate.Num(), rate.Den(), ff.AVUtil_rational_q2d(rate))
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_channel_layout and av_opt_get_channel_layout
+
+func Test_avutil_opt_009(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_MP2)
+	if codec == nil {
+		t.Skip("MP2 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting channel layout option
+	testLayout := ff.AV_CHANNEL_LAYOUT_STEREO()
+	if err := ff.AVUtil_opt_set_channel_layout(unsafe.Pointer(ctx), "channel_layout", &testLayout, 0); err != nil {
+		t.Logf("Warning: could not set channel_layout option: %v", err)
+	}
+
+	// Test getting channel layout option
+	layout, err := ff.AVUtil_opt_get_channel_layout(unsafe.Pointer(ctx), "channel_layout", 0)
+	if err == nil {
+		if desc, err2 := ff.AVUtil_channel_layout_describe(layout); err2 == nil {
+			t.Logf("channel_layout = %s (channels: %d)", desc, layout.NumChannels())
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_bin
+
+func Test_avutil_opt_010(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting binary option (extradata if supported)
+	testData := []byte{0x01, 0x02, 0x03, 0x04}
+	if err := ff.AVUtil_opt_set_bin(unsafe.Pointer(ctx), "extradata", testData, 0); err != nil {
+		t.Logf("Info: binary option test completed (extradata may not be settable via opt): %v", err)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_find
+
+func Test_avutil_opt_011(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test finding an option
+	opt := ff.AVUtil_opt_find(unsafe.Pointer(ctx), "b", "", 0, 0)
+	if opt != nil {
+		t.Logf("Found option 'b' (bitrate)")
+	} else {
+		t.Error("Failed to find option 'b'")
+	}
+
+	// Test finding non-existent option
+	opt = ff.AVUtil_opt_find(unsafe.Pointer(ctx), "nonexistent_option", "", 0, 0)
+	if opt == nil {
+		t.Logf("Correctly returned nil for non-existent option")
+	} else {
+		t.Error("Should have returned nil for non-existent option")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_find2
+
+func Test_avutil_opt_012(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test finding an option with target object
+	opt, targetObj := ff.AVUtil_opt_find2(unsafe.Pointer(ctx), "b", "", 0, 0)
+	if opt != nil {
+		t.Logf("Found option 'b' (bitrate)")
+		if targetObj != nil {
+			t.Logf("Target object is non-nil")
+		}
+	} else {
+		t.Error("Failed to find option 'b'")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_defaults
+
+func Test_avutil_opt_013(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting defaults
+	ff.AVUtil_opt_set_defaults(unsafe.Pointer(ctx))
+	t.Logf("Set defaults on codec context")
+
+	// Verify a default value was set
+	if bitrate, err := ff.AVUtil_opt_get_int(unsafe.Pointer(ctx), "b", 0); err == nil {
+		t.Logf("Default bitrate = %d", bitrate)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_set_defaults2
+
+func Test_avutil_opt_014(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test setting defaults with flags
+	ff.AVUtil_opt_set_defaults2(unsafe.Pointer(ctx), 0, 0)
+	t.Logf("Set defaults2 on codec context")
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_copy
+
+func Test_avutil_opt_015(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	src := ff.AVCodec_alloc_context(codec)
+	if src == nil {
+		t.Fatal("Failed to allocate source codec context")
+	}
+	defer ff.AVCodec_free_context(src)
+
+	dst := ff.AVCodec_alloc_context(codec)
+	if dst == nil {
+		t.Fatal("Failed to allocate destination codec context")
+	}
+	defer ff.AVCodec_free_context(dst)
+
+	// Set some options on source
+	const testBitrate = 500000
+	if err := ff.AVUtil_opt_set_int(unsafe.Pointer(src), "b", testBitrate, 0); err != nil {
+		t.Logf("Warning: could not set bitrate on source: %v", err)
+	}
+
+	// Copy options from source to destination
+	if err := ff.AVUtil_opt_copy(unsafe.Pointer(dst), unsafe.Pointer(src)); err != nil {
+		t.Errorf("Failed to copy options: %v", err)
+	} else {
+		t.Logf("Successfully copied options")
+
+		// Verify the copy
+		if bitrate, err := ff.AVUtil_opt_get_int(unsafe.Pointer(dst), "b", 0); err == nil {
+			t.Logf("Destination bitrate = %d", bitrate)
+			if bitrate != testBitrate {
+				t.Logf("Note: bitrate value differs: expected %d, got %d", testBitrate, bitrate)
+			}
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_is_set_to_default_by_name
+
+func Test_avutil_opt_017(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Set defaults first
+	ff.AVUtil_opt_set_defaults(unsafe.Pointer(ctx))
+
+	// Check if option is set to default
+	result := ff.AVUtil_opt_is_set_to_default_by_name(unsafe.Pointer(ctx), "b", 0)
+	if result == 1 {
+		t.Logf("Option 'b' is set to default")
+	} else if result == 0 {
+		t.Logf("Option 'b' is not set to default")
+	} else {
+		t.Logf("Error checking if option is set to default: %d", result)
+	}
+
+	// Change the option value
+	if err := ff.AVUtil_opt_set_int(unsafe.Pointer(ctx), "b", 1000000, 0); err == nil {
+		// Check again
+		result := ff.AVUtil_opt_is_set_to_default_by_name(unsafe.Pointer(ctx), "b", 0)
+		if result == 0 {
+			t.Logf("Option 'b' is now not set to default (as expected)")
+		} else if result == 1 {
+			t.Logf("Note: Option 'b' still reports as default")
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_serialize
+
+func Test_avutil_opt_018(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Set some options
+	ff.AVUtil_opt_set_int(unsafe.Pointer(ctx), "b", 400000, 0)
+	ff.AVUtil_opt_set(unsafe.Pointer(ctx), "preset", "fast", 0)
+
+	// Serialize options
+	serialized := ff.AVUtil_opt_serialize(unsafe.Pointer(ctx), 0, 0, '=', ':')
+	if serialized != "" {
+		t.Logf("Serialized options: %s", serialized)
+	} else {
+		t.Logf("Serialization returned empty string (may be normal)")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_show2
+
+func Test_avutil_opt_019(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Show options (outputs to FFmpeg log)
+	if err := ff.AVUtil_opt_show2(unsafe.Pointer(ctx), nil, 0, 0); err != nil {
+		t.Errorf("Failed to show options: %v", err)
+	} else {
+		t.Logf("Options shown (check FFmpeg log output)")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_query_ranges
+
+func Test_avutil_opt_020(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Query ranges for an option (not all options support range queries)
+	var ranges *ff.AVOptionRanges
+	if err := ff.AVUtil_opt_query_ranges(&ranges, unsafe.Pointer(ctx), "b", 0); err != nil {
+		t.Logf("Option 'b' does not support range queries (expected): %v", err)
+	} else if ranges != nil {
+		t.Logf("Successfully queried ranges for option 'b'")
+		ff.AVUtil_opt_freep_ranges(&ranges)
+		if ranges == nil {
+			t.Logf("Ranges successfully freed")
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST av_opt_next and av_opt_list
+
+func Test_avutil_opt_021(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test iterating with av_opt_next
+	count := 0
+	var prev *ff.AVOption
+	for {
+		opt := ff.AVUtil_opt_next(unsafe.Pointer(ctx), prev)
+		if opt == nil {
+			break
+		}
+		count++
+		if count <= 5 {
+			t.Logf("Option %d: name=%s, type=%v, help=%s", count, opt.Name(), opt.Type(), opt.Help())
+		}
+		prev = opt
+	}
+	t.Logf("Total options found with av_opt_next: %d", count)
+
+	if count == 0 {
+		t.Error("Expected to find at least some options")
+	}
+}
+
+func Test_avutil_opt_022(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Test getting all options as a slice
+	options := ff.AVUtil_opt_list(unsafe.Pointer(ctx))
+	t.Logf("Total options found with av_opt_list: %d", len(options))
+
+	if len(options) == 0 {
+		t.Error("Expected to find at least some options")
+	}
+
+	// Check first few options
+	for i, opt := range options {
+		if i >= 5 {
+			break
+		}
+		t.Logf("Option %d: name=%s, type=%v", i+1, opt.Name(), opt.Type())
+	}
+
+	// Verify we can find known options
+	foundBitrate := false
+	for _, opt := range options {
+		if opt.Name() == "b" {
+			foundBitrate = true
+			t.Logf("Found bitrate option: offset=%d", opt.Offset())
+			break
+		}
+	}
+
+	if !foundBitrate {
+		t.Error("Expected to find 'b' (bitrate) option")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST AVOption JSON marshaling
+
+func Test_avutil_opt_023(t *testing.T) {
+	codec := ff.AVCodec_find_encoder(ff.AV_CODEC_ID_H264)
+	if codec == nil {
+		t.Skip("H264 encoder not found")
+	}
+
+	ctx := ff.AVCodec_alloc_context(codec)
+	if ctx == nil {
+		t.Fatal("Failed to allocate codec context")
+	}
+	defer ff.AVCodec_free_context(ctx)
+
+	// Get all options
+	options := ff.AVUtil_opt_list(unsafe.Pointer(ctx))
+	if len(options) == 0 {
+		t.Fatal("Expected to find options")
+	}
+
+	// Marshal first option to JSON
+	data, err := json.Marshal(options[0])
+	if err != nil {
+		t.Fatalf("Failed to marshal option to JSON: %v", err)
+	}
+	t.Logf("First option JSON: %s", string(data))
+
+	// Verify JSON structure
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Check required fields
+	if _, ok := result["name"]; !ok {
+		t.Error("JSON missing 'name' field")
+	}
+	if _, ok := result["type"]; !ok {
+		t.Error("JSON missing 'type' field")
+	}
+
+	// Verify type is a string, not a number
+	if typeVal, ok := result["type"].(string); !ok {
+		t.Errorf("JSON 'type' field should be a string, got %T", result["type"])
+	} else {
+		t.Logf("Type is string: %s", typeVal)
+	}
+
+	// Marshal array of options
+	firstFive := options[:5]
+	arrayData, err := json.Marshal(firstFive)
+	if err != nil {
+		t.Fatalf("Failed to marshal options array to JSON: %v", err)
+	}
+	t.Logf("First 5 options JSON: %s", string(arrayData))
+
+	// Pretty print
+	prettyData, err := json.MarshalIndent(firstFive, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal pretty JSON: %v", err)
+	}
+	t.Logf("Pretty JSON:\n%s", string(prettyData))
+}


### PR DESCRIPTION
This PR adds comprehensive FFmpeg AVOption API bindings to enable runtime inspection and configuration of codecs, filters, and formats. The implementation exposes options metadata through JSON APIs, making it possible for clients to discover and configure available options dynamically.

Key changes:

- New AVOption API bindings in sys/ffmpeg80/avutil_opt.go with get/set functions for all FFmpeg option types (string, int, double, rational, pixel format, etc.)
- Added PrivClass() methods to AVCodec, AVFilter, AVInputFormat, and AVOutputFormat to expose their option classes
- Extended Codec, Filter, and Format schema types to include options lists in JSON responses
