### PR TITLE
Added XMP and RAW support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ JOBS ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 FFMPEG_VERSION ?= ffmpeg-8.0.1
 SYS_VERSION ?= ffmpeg80
 CHROMAPRINT_VERSION ?= chromaprint-1.5.1
-LIBEXIF_VERSION ?= libexif-0.6.26
+LIBEXIF_VERSION ?= 0.6.26
+LIBRAW_VERSION ?= 0.22.1
 
 # Set OS and Architecture (must be before CGO configuration)
 ARCH ?= $(shell arch | tr A-Z a-z | sed 's/x86_64/amd64/' | sed 's/i386/amd64/' | sed 's/armv7l/arm/' | sed 's/aarch64/arm64/')
@@ -145,24 +146,60 @@ chromaprint: chromaprint-build
 	@sed -i.bak 's/Libs: -L\${libdir} -lchromaprint/Libs: -L\${libdir} -lchromaprint -lstdc++ -lavutil/g' "${PREFIX}/lib/pkgconfig/libchromaprint.pc"
 	@rm -f "${PREFIX}/lib/pkgconfig/libchromaprint.pc.bak"
 
+###############################################################################
+# LIBRAW
+
+# Download libraw sources
+${BUILD_DIR}/libraw-${LIBRAW_VERSION}:
+	if [ ! -d "$(BUILD_DIR)/libraw-$(LIBRAW_VERSION)" ]; then \
+		echo "Downloading $(LIBRAW_VERSION)"; \
+		mkdir -p $(BUILD_DIR)/libraw-${LIBRAW_VERSION}; \
+		curl -L -o $(BUILD_DIR)/libraw.tar.gz https://www.libraw.org/data/LibRaw-${LIBRAW_VERSION}.tar.gz; \
+		tar -xzf $(BUILD_DIR)/libraw.tar.gz -C $(BUILD_DIR); \
+		rm -f $(BUILD_DIR)/libraw.tar.gz; \
+	fi
+
+.PHONY: libraw-configure
+libraw-configure: mkdir ${BUILD_DIR}/libraw-${LIBRAW_VERSION}
+	@echo "Configuring ${LIBRAW_VERSION} => ${PREFIX}"
+	@cd ${BUILD_DIR}/libraw-${LIBRAW_VERSION} && ./configure \
+		--prefix="$(shell realpath ${PREFIX})" \
+		--enable-static --disable-shared \
+		LIBS="$(if $(filter darwin,$(OS)),-lc++,-lstdc++)"
+
+# Build libraw
+.PHONY: libraw-build
+libraw-build: libraw-configure
+	@echo "Building libraw-${LIBRAW_VERSION} with ${JOBS} jobs"
+	@cd $(BUILD_DIR)/libraw-$(LIBRAW_VERSION) && make -j$(JOBS) lib/libraw.la lib/libraw_r.la
+
+# Install libraw
+# Patch pkg-config to add -lz (required for DNG deflate support)
+.PHONY: libraw
+libraw: libraw-build
+	@echo "Installing ${LIBRAW_VERSION} => ${PREFIX}"
+	@cd $(BUILD_DIR)/libraw-$(LIBRAW_VERSION) && make install
+	@sed -i.bak 's|-lraw -lstdc++|-lraw -lstdc++ -lz|' "${PREFIX}/lib/pkgconfig/libraw.pc"
+	@rm -f "${PREFIX}/lib/pkgconfig/libraw.pc.bak"
+	@${GO} clean -cache
 
 ###############################################################################
 # LIBEXIF
 
 # Download libexif sources
-${BUILD_DIR}/${LIBEXIF_VERSION}:
-	@if [ ! -d "$(BUILD_DIR)/$(LIBEXIF_VERSION)" ]; then \
+${BUILD_DIR}/libexif-${LIBEXIF_VERSION}:
+	@if [ ! -d "$(BUILD_DIR)/libexif-$(LIBEXIF_VERSION)" ]; then \
 		echo "Downloading $(LIBEXIF_VERSION)"; \
-		mkdir -p $(BUILD_DIR)/${LIBEXIF_VERSION}; \
-		curl -L -o $(BUILD_DIR)/libexif.tar.gz https://github.com/libexif/libexif/releases/download/v0.6.26/$(LIBEXIF_VERSION).tar.gz; \
+		mkdir -p $(BUILD_DIR)/libexif-${LIBEXIF_VERSION}; \
+		curl -L -o $(BUILD_DIR)/libexif.tar.gz https://github.com/libexif/libexif/releases/download/v$(LIBEXIF_VERSION)/libexif-$(LIBEXIF_VERSION).tar.gz; \
 		tar -xzf $(BUILD_DIR)/libexif.tar.gz -C $(BUILD_DIR); \
 		rm -f $(BUILD_DIR)/libexif.tar.gz; \
 	fi
 
 .PHONY: libexif-configure
-libexif-configure: mkdir ${BUILD_DIR}/${LIBEXIF_VERSION}
+libexif-configure: mkdir ${BUILD_DIR}/libexif-${LIBEXIF_VERSION}
 	@echo "Configuring ${LIBEXIF_VERSION} => ${PREFIX}"
-	@cd ${BUILD_DIR}/${LIBEXIF_VERSION} && ./configure \
+	@cd ${BUILD_DIR}/libexif-${LIBEXIF_VERSION} && ./configure \
 		--disable-docs --enable-year2038  \
 		--prefix="$(shell realpath ${PREFIX})" \
 		--enable-static --disable-shared
@@ -172,7 +209,6 @@ libexif-configure: mkdir ${BUILD_DIR}/${LIBEXIF_VERSION}
 libexif-build: libexif-configure
 	@echo "Building ${LIBEXIF_VERSION} with ${JOBS} jobs"
 	@cd $(BUILD_DIR)/$(LIBEXIF_VERSION) && make -j$(JOBS)
-
 
 # Install libexif
 .PHONY: libexif
@@ -201,7 +237,7 @@ docker-push: docker-dep
 # TESTS
 
 .PHONY: test
-test: ffmpeg chromaprint test-ffmpeg test-chromaprint test-exif
+test: ffmpeg chromaprint test-ffmpeg test-chromaprint test-exif test-raw
 	@echo ... test pkg/file
 	@${GO} test ${ARGS} ./pkg/file
 
@@ -216,6 +252,12 @@ test-exif:
 	@echo ... test sys/libexif pkg/exif
 	@${CGO_ENV} ${GO} test ${ARGS} ./sys/libexif
 	@${CGO_ENV} ${GO} test ${ARGS} ./pkg/exif
+
+.PHONY: test-raw
+test-raw:
+	@echo ... test sys/libraw pkg/raw
+	@${CGO_ENV} ${GO} test ${ARGS} ./sys/libraw
+	@${CGO_ENV} ${GO} test ${ARGS} ./pkg/raw
 
 .PHONY: test-sys
 test-sys: go-dep go-tidy

--- a/etc/test/bridge-2.xmp
+++ b/etc/test/bridge-2.xmp
@@ -1,0 +1,147 @@
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 9.1-c002 165.59ab891, 2024/09/18-09:57:10        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:exif="http://ns.adobe.com/exif/1.0/"
+            xmlns:tiff="http://ns.adobe.com/tiff/1.0/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:photoshop="http://ns.adobe.com/photoshop/1.0/"
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/"
+            xmlns:Iptc4xmpCore="http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/"
+            xmlns:kbrg="http://ns.adobe.com/bridge/1.0/">
+         <exif:ExifVersion>0231</exif:ExifVersion>
+         <exif:PixelXDimension>1599</exif:PixelXDimension>
+         <exif:PixelYDimension>1066</exif:PixelYDimension>
+         <exif:ColorSpace>65535</exif:ColorSpace>
+         <exif:GPSLatitude>52,26.5849N</exif:GPSLatitude>
+         <exif:GPSProcessingMethod>MANUAL</exif:GPSProcessingMethod>
+         <exif:GPSLongitude>013,34.5968E</exif:GPSLongitude>
+         <exif:GPSAltitudeRef>0</exif:GPSAltitudeRef>
+         <exif:GPSAltitude>1500000/100</exif:GPSAltitude>
+         <exif:DateTimeOriginal>2021-01-24T08:28:28+01:00</exif:DateTimeOriginal>
+         <tiff:Orientation>1</tiff:Orientation>
+         <tiff:ImageWidth>1599</tiff:ImageWidth>
+         <tiff:ImageLength>1066</tiff:ImageLength>
+         <tiff:PhotometricInterpretation>2</tiff:PhotometricInterpretation>
+         <tiff:SamplesPerPixel>3</tiff:SamplesPerPixel>
+         <tiff:XResolution>1/1</tiff:XResolution>
+         <tiff:YResolution>1/1</tiff:YResolution>
+         <tiff:ResolutionUnit>1</tiff:ResolutionUnit>
+         <tiff:BitsPerSample>
+            <rdf:Seq>
+               <rdf:li>8</rdf:li>
+               <rdf:li>8</rdf:li>
+               <rdf:li>8</rdf:li>
+            </rdf:Seq>
+         </tiff:BitsPerSample>
+         <xmpMM:DocumentID>7386F4EF875E59E482D08597C0D25DB7</xmpMM:DocumentID>
+         <xmpMM:OriginalDocumentID>7386F4EF875E59E482D08597C0D25DB7</xmpMM:OriginalDocumentID>
+         <xmpMM:InstanceID>xmp.iid:5b51221e-0c75-412c-93da-f71cb4a8a0d7</xmpMM:InstanceID>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:113d1054-020b-4d10-bc66-38aff071f520</stEvt:instanceID>
+                  <stEvt:when>2025-07-25T14:28:38+02:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Photoshop Camera Raw 17.4</stEvt:softwareAgent>
+                  <stEvt:changed>/metadata</stEvt:changed>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:5b51221e-0c75-412c-93da-f71cb4a8a0d7</stEvt:instanceID>
+                  <stEvt:when>2026-04-28T11:54:38+02:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Photoshop Camera Raw 17.4</stEvt:softwareAgent>
+                  <stEvt:changed>/metadata</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <dc:format>image/jpeg</dc:format>
+         <dc:creator>
+            <rdf:Seq>
+               <rdf:li>Theresa Creator</rdf:li>
+            </rdf:Seq>
+         </dc:creator>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Description from Theresa</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <dc:subject>
+            <rdf:Bag>
+               <rdf:li>keyworda</rdf:li>
+               <rdf:li>keywordb</rdf:li>
+               <rdf:li>keywordc</rdf:li>
+            </rdf:Bag>
+         </dc:subject>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Document Title Created with Bridge</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:rights>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">copyright notice</rdf:li>
+            </rdf:Alt>
+         </dc:rights>
+         <photoshop:ColorMode>3</photoshop:ColorMode>
+         <photoshop:AuthorsPosition>Bridge Job Title</photoshop:AuthorsPosition>
+         <photoshop:Headline>Headline from Photoshop</photoshop:Headline>
+         <photoshop:DateCreated>2026-05-01T02:30:15</photoshop:DateCreated>
+         <xmp:Label>Review</xmp:Label>
+         <xmp:MetadataDate>2026-04-28T11:54:38+02:00</xmp:MetadataDate>
+         <xmp:Rating>4</xmp:Rating>
+         <xmpRights:WebStatement>legal url.de</xmpRights:WebStatement>
+         <xmpRights:UsageTerms>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">right usage terms</rdf:li>
+            </rdf:Alt>
+         </xmpRights:UsageTerms>
+         <Iptc4xmpCore:CreatorContactInfo rdf:parseType="Resource">
+            <Iptc4xmpCore:CiAdrExtadr>Some Street</Iptc4xmpCore:CiAdrExtadr>
+            <Iptc4xmpCore:CiAdrCity>Berlin</Iptc4xmpCore:CiAdrCity>
+            <Iptc4xmpCore:CiAdrRegion>Berlin</Iptc4xmpCore:CiAdrRegion>
+            <Iptc4xmpCore:CiAdrPcode>12163</Iptc4xmpCore:CiAdrPcode>
+            <Iptc4xmpCore:CiAdrCtry>Deutschland</Iptc4xmpCore:CiAdrCtry>
+            <Iptc4xmpCore:CiTelWork>030/123456</Iptc4xmpCore:CiTelWork>
+            <Iptc4xmpCore:CiEmailWork>test@mail.com</Iptc4xmpCore:CiEmailWork>
+            <Iptc4xmpCore:CiUrlWork>www.website.de</Iptc4xmpCore:CiUrlWork>
+         </Iptc4xmpCore:CreatorContactInfo>
+         <Iptc4xmpCore:AltTextAccessibility>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">nice alt text</rdf:li>
+            </rdf:Alt>
+         </Iptc4xmpCore:AltTextAccessibility>
+         <Iptc4xmpCore:ExtDescrAccessibility>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">extended description</rdf:li>
+            </rdf:Alt>
+         </Iptc4xmpCore:ExtDescrAccessibility>
+         <kbrg:InitialEditCaptureTime>2021-01-24T03:28:28+01:00</kbrg:InitialEditCaptureTime>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>

--- a/etc/test/pdfx-xmp-example.xmp
+++ b/etc/test/pdfx-xmp-example.xmp
@@ -1,0 +1,118 @@
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 4.2.1-c043 52.372728, 2009/01/18-15:56:37        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+         <dc:format>application/pdf</dc:format>
+         <dc:identifier>10.1016/j.aca.2010.07.015</dc:identifier>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Preparation of a reference mussel tissue material for polycyclic aromatic hydrocarbons and trace metals determination</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:creator>
+            <rdf:Seq>
+               <rdf:li>Patricia Navarro</rdf:li>
+               <rdf:li>Luis Bartolomé</rdf:li>
+               <rdf:li>Juan Carlos Raposo</rdf:li>
+               <rdf:li>Olatz Zuloaga</rdf:li>
+               <rdf:li>Gorka Arana</rdf:li>
+               <rdf:li>Nestor Etxebarria</rdf:li>
+            </rdf:Seq>
+         </dc:creator>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Analytica Chimica Acta, 675 (2010) 91-96. 10.1016/j.aca.2010.07.015</rdf:li>
+            </rdf:Alt>
+         </dc:description>
+         <dc:publisher>
+            <rdf:Bag>
+               <rdf:li>Elsevier B.V.</rdf:li>
+            </rdf:Bag>
+         </dc:publisher>
+         <dc:subject>
+            <rdf:Bag>
+               <rdf:li>Quality control</rdf:li>
+               <rdf:li>Laboratory reference material</rdf:li>
+               <rdf:li>Mussel tissue</rdf:li>
+               <rdf:li>Polycyclic aromatic hydrocarbons</rdf:li>
+               <rdf:li>Trace metals</rdf:li>
+            </rdf:Bag>
+         </dc:subject>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/">
+         <prism:aggregationType>journal</prism:aggregationType>
+         <prism:publicationName>Analytica Chimica Acta</prism:publicationName>
+         <prism:copyright>© 2010 Elsevier B.V. All rights reserved.</prism:copyright>
+         <prism:issn>0003-2670</prism:issn>
+         <prism:volume>675</prism:volume>
+         <prism:number>1</prism:number>
+         <prism:coverDisplayDate>18 August 2010</prism:coverDisplayDate>
+         <prism:coverDate>2010-08-18</prism:coverDate>
+         <prism:pageRange>91-96</prism:pageRange>
+         <prism:startingPage>91</prism:startingPage>
+         <prism:endingPage>96</prism:endingPage>
+         <prism:doi>10.1016/j.aca.2010.07.015</prism:doi>
+         <prism:url>http://dx.doi.org/10.1016/j.aca.2010.07.015</prism:url>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/">
+         <xmp:CreatorTool>Elsevier</xmp:CreatorTool>
+         <xmp:ModifyDate>2010-08-24T09:06:08+02:00</xmp:ModifyDate>
+         <xmp:CreateDate>2010-08-01T04:36:20Z</xmp:CreateDate>
+         <xmp:MetadataDate>2010-08-24T09:06:08+02:00</xmp:MetadataDate>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xmpRights="http://ns.adobe.com/xap/1.0/rights/">
+         <xmpRights:Marked>True</xmpRights:Marked>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <pdf:Producer>Acrobat Distiller 8.1.0 (Windows)</pdf:Producer>
+         <pdf:Trapped>Unknown</pdf:Trapped>
+         <pdf:Keywords>Quality control; Laboratory reference material; Mussel tissue; Polycyclic aromatic hydrocarbons; Trace metals</pdf:Keywords>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/">
+         <xmpMM:DocumentID>uuid:16b5ae77-6164-45a5-a950-9a1d91d80a2f</xmpMM:DocumentID>
+         <xmpMM:InstanceID>uuid:3607da1d-24f0-4999-8469-f7b87b2b6366</xmpMM:InstanceID>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:pdfx="http://ns.adobe.com/pdfx/1.3/">
+         <pdfx:robots>noindex</pdfx:robots>
+         <pdfx:CrossmarkMajorVersionDate>2010-04-23</pdfx:CrossmarkMajorVersionDate>
+         <pdfx:CrossmarkDomainExclusive>true</pdfx:CrossmarkDomainExclusive>
+         <pdfx:ElsevierWebPDFSpecifications>6.1</pdfx:ElsevierWebPDFSpecifications>
+         <pdfx:CrossMarkDomains>
+            <rdf:Seq>
+               <rdf:li>sciencedirect.com</rdf:li>
+               <rdf:li>elsevier.com</rdf:li>
+            </rdf:Seq>
+         </pdfx:CrossMarkDomains>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+

--- a/etc/test/random-xmp-example.xmp
+++ b/etc/test/random-xmp-example.xmp
@@ -1,0 +1,47 @@
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 4.0-c316 44.253921, Sun Oct 01 2006 17:14:39">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <pdf:Keywords>XMP metadata  Exif IPTC PSIR  file I/O</pdf:Keywords>
+         <pdf:Copyright>Copyright 4008, Adobe Systems Incorporated, all rights reserved.</pdf:Copyright>
+         <pdf:Marked>True</pdf:Marked>
+         <pdf:Producer>Acrobat Distiller 8.1.0 (Windows)</pdf:Producer>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xap="http://ns.adobe.com/xap/1.0/">
+         <xap:ModifyDate>2008-09-16T08:43:43-07:00</xap:ModifyDate>
+         <xap:CreatorTool>FrameMaker 7.2</xap:CreatorTool>
+         <xap:CreateDate>2008-09-16T08:19:40Z</xap:CreateDate>
+         <xap:MetadataDate>2008-09-16T08:43:43-07:00</xap:MetadataDate>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:dc="http://purl.org/dc/elements/1.1/">
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">XMP Specification Part 3: Storage in Files</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <dc:creator>
+            <rdf:Seq>
+               <rdf:li>Adobe Developer Technologies</rdf:li>
+            </rdf:Seq>
+         </dc:creator>
+         <dc:description>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">Storage and handling of XMP in files, and legacy metadata in still image file formats. </rdf:li>
+            </rdf:Alt>
+         </dc:description>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:pdfx="http://ns.adobe.com/pdfx/1.3/">
+         <pdfx:Copyright>Copyright 2008, Adobe Systems Incorporated, all rights reserved.</pdfx:Copyright>
+         <pdfx:Marked>True</pdfx:Marked>
+      </rdf:Description>
+      <rdf:Description rdf:about=""
+            xmlns:xapMM="http://ns.adobe.com/xap/1.0/mm/">
+         <xapMM:DocumentID>uuid:a2a0d182-7b1c-4801-a22c-d610115116bd</xapMM:DocumentID>
+         <xapMM:InstanceID>uuid:1a365cee-e070-4b52-8278-db5e46b20a4c</xapMM:InstanceID>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>

--- a/etc/test/sample.xmp
+++ b/etc/test/sample.xmp
@@ -1,0 +1,38 @@
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+        xmp:Rating="3"
+        dc:format="image/jpeg">
+      <dc:title>
+        <rdf:Alt>
+          <rdf:li xml:lang="x-default">Sample Image</rdf:li>
+          <rdf:li xml:lang="en">Sample Image</rdf:li>
+          <rdf:li xml:lang="de">Beispielbild</rdf:li>
+        </rdf:Alt>
+      </dc:title>
+      <dc:description>
+        <rdf:Alt>
+          <rdf:li xml:lang="x-default">A sample XMP document for testing</rdf:li>
+        </rdf:Alt>
+      </dc:description>
+      <dc:creator>
+        <rdf:Seq>
+          <rdf:li>Jane Doe</rdf:li>
+          <rdf:li>John Smith</rdf:li>
+        </rdf:Seq>
+      </dc:creator>
+      <dc:subject>
+        <rdf:Bag>
+          <rdf:li>nature</rdf:li>
+          <rdf:li>landscape</rdf:li>
+          <rdf:li>photography</rdf:li>
+        </rdf:Bag>
+      </dc:subject>
+      <xmp:CreateDate>2024-01-15T10:30:00</xmp:CreateDate>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+<?xpacket end="w"?>

--- a/pkg/exif/tag.go
+++ b/pkg/exif/tag.go
@@ -88,9 +88,17 @@ func (t *Tag) IFD() IFD {
 	return t.ifd
 }
 
-// Key returns the tag name (implements media.Metadata).
+// Key returns "tiff:Name" for IFD0/IFD1 tags and "exif:Name" for EXIF/GPS/Interop
+// tags (implements media.Metadata). The prefix aligns with XMP namespace conventions
+// so cross-source lookups work uniformly across pkg/exif and pkg/xmp.
 func (t *Tag) Key() string {
-	return libexif.Exif_tag_get_name_in_ifd(libexif.Tag(t.tag), libexif.IFD(t.ifd))
+	name := libexif.Exif_tag_get_name_in_ifd(libexif.Tag(t.tag), libexif.IFD(t.ifd))
+	switch libexif.IFD(t.ifd) {
+	case libexif.EXIF_IFD_0, libexif.EXIF_IFD_1:
+		return "tiff:" + name
+	default:
+		return "exif:" + name
+	}
 }
 
 // Name returns the tag name.

--- a/pkg/raw/meta.go
+++ b/pkg/raw/meta.go
@@ -1,0 +1,93 @@
+package raw
+
+import (
+	"encoding/json"
+	"fmt"
+	"image"
+	"strings"
+	"time"
+
+	// Packages
+	media "github.com/mutablelogic/go-media"
+	libraw "github.com/mutablelogic/go-media/sys/libraw"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// Meta is a single key/value metadata field from a RAW file.
+// Keys follow XMP namespace conventions (tiff:Make, exif:ISOSpeedRatings, etc.).
+type Meta struct {
+	key string
+	val string
+	any any
+}
+
+var _ media.Metadata = (*Meta)(nil)
+
+////////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+func (m *Meta) Key() string        { return m.key }
+func (m *Meta) Value() string      { return m.val }
+func (m *Meta) Bytes() []byte      { return nil }
+func (m *Meta) Image() image.Image { return nil }
+func (m *Meta) Any() any           { return m.any }
+
+func (m *Meta) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}{Key: m.key, Value: m.val})
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PRIVATE
+
+func newMetadata(r *RAW) []media.Metadata {
+	iparams := libraw.Libraw_get_iparams(r.data)
+	other := libraw.Libraw_get_imgother(r.data)
+
+	var result []media.Metadata
+	add := func(key, val string, typed any) {
+		if val != "" {
+			result = append(result, &Meta{key: key, val: val, any: typed})
+		}
+	}
+
+	add("tiff:Make", strings.TrimSpace(libraw.IParams_make(iparams)), strings.TrimSpace(libraw.IParams_make(iparams)))
+	add("tiff:Model", strings.TrimSpace(libraw.IParams_model(iparams)), strings.TrimSpace(libraw.IParams_model(iparams)))
+	add("tiff:Software", strings.TrimSpace(libraw.IParams_software(iparams)), strings.TrimSpace(libraw.IParams_software(iparams)))
+
+	if iso := libraw.ImgOther_iso_speed(other); iso > 0 {
+		add("exif:ISOSpeedRatings", fmt.Sprintf("%.0f", iso), iso)
+	}
+	if s := libraw.ImgOther_shutter(other); s > 0 {
+		add("exif:ExposureTime", shutterStr(s), s)
+	}
+	if ap := libraw.ImgOther_aperture(other); ap > 0 {
+		add("exif:FNumber", fmt.Sprintf("f/%.1f", ap), ap)
+	}
+	if fl := libraw.ImgOther_focal_len(other); fl > 0 {
+		add("exif:FocalLength", fmt.Sprintf("%.0fmm", fl), fl)
+	}
+	if ts := libraw.ImgOther_timestamp(other); ts > 0 {
+		t := time.Unix(ts, 0)
+		add("exif:DateTimeOriginal", t.Format(time.RFC3339), t)
+	}
+	if desc := strings.TrimSpace(libraw.ImgOther_desc(other)); desc != "" {
+		add("dc:description", desc, desc)
+	}
+	if artist := strings.TrimSpace(libraw.ImgOther_artist(other)); artist != "" {
+		add("dc:creator", artist, artist)
+	}
+
+	return result
+}
+
+func shutterStr(s float32) string {
+	if s >= 1 {
+		return fmt.Sprintf("%.1fs", s)
+	}
+	return fmt.Sprintf("1/%.0f", 1.0/s)
+}

--- a/pkg/raw/raw.go
+++ b/pkg/raw/raw.go
@@ -1,0 +1,282 @@
+package raw
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	_ "image/jpeg"
+	"io"
+	"os"
+	"time"
+
+	// Packages
+	media "github.com/mutablelogic/go-media"
+	libraw "github.com/mutablelogic/go-media/sys/libraw"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// RAW wraps a libraw data handle for decoding RAW image files.
+type RAW struct {
+	data *libraw.Data
+}
+
+var _ io.Closer = (*RAW)(nil)
+
+////////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+// Open opens a RAW image file by path.
+func Open(path string) (*RAW, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, media.ErrNotFound.Withf("%q", path)
+	}
+	data := libraw.Libraw_init(0)
+	if data == nil {
+		return nil, media.ErrInternalError.With("libraw init failed")
+	}
+	if rc := libraw.Libraw_open_file(data, path); rc != 0 {
+		libraw.Libraw_close(data)
+		return nil, media.ErrBadParameter.With(libraw.Libraw_strerror(rc))
+	}
+	return &RAW{data: data}, nil
+}
+
+// Read opens a RAW image from a reader.
+func Read(r io.Reader) (*RAW, error) {
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(buf)
+}
+
+// Parse opens a RAW image from a byte slice.
+func Parse(buf []byte) (*RAW, error) {
+	if len(buf) == 0 {
+		return nil, media.ErrBadParameter.With("empty data")
+	}
+	data := libraw.Libraw_init(0)
+	if data == nil {
+		return nil, media.ErrInternalError.With("libraw init failed")
+	}
+	if rc := libraw.Libraw_open_buffer(data, buf); rc != 0 {
+		libraw.Libraw_close(data)
+		return nil, media.ErrBadParameter.With(libraw.Libraw_strerror(rc))
+	}
+	return &RAW{data: data}, nil
+}
+
+// Close releases the underlying libraw resources.
+func (r *RAW) Close() error {
+	if r.data != nil {
+		libraw.Libraw_close(r.data)
+		r.data = nil
+	}
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ACCESSORS
+
+// Make returns the camera manufacturer.
+func (r *RAW) Make() string {
+	return libraw.IParams_make(libraw.Libraw_get_iparams(r.data))
+}
+
+// Model returns the camera model.
+func (r *RAW) Model() string {
+	return libraw.IParams_model(libraw.Libraw_get_iparams(r.data))
+}
+
+// Software returns the firmware or software string embedded in the file.
+func (r *RAW) Software() string {
+	return libraw.IParams_software(libraw.Libraw_get_iparams(r.data))
+}
+
+// ISOSpeed returns the ISO speed rating.
+func (r *RAW) ISOSpeed() float32 {
+	return libraw.ImgOther_iso_speed(libraw.Libraw_get_imgother(r.data))
+}
+
+// Shutter returns the exposure time in seconds.
+func (r *RAW) Shutter() float32 {
+	return libraw.ImgOther_shutter(libraw.Libraw_get_imgother(r.data))
+}
+
+// Aperture returns the f-number.
+func (r *RAW) Aperture() float32 {
+	return libraw.ImgOther_aperture(libraw.Libraw_get_imgother(r.data))
+}
+
+// FocalLength returns the focal length in mm.
+func (r *RAW) FocalLength() float32 {
+	return libraw.ImgOther_focal_len(libraw.Libraw_get_imgother(r.data))
+}
+
+// Timestamp returns the capture time.
+func (r *RAW) Timestamp() time.Time {
+	return time.Unix(libraw.ImgOther_timestamp(libraw.Libraw_get_imgother(r.data)), 0)
+}
+
+// Width returns the processed image width in pixels (after crop/rotation).
+func (r *RAW) Width() int {
+	return libraw.Libraw_get_iwidth(r.data)
+}
+
+// Height returns the processed image height in pixels (after crop/rotation).
+func (r *RAW) Height() int {
+	return libraw.Libraw_get_iheight(r.data)
+}
+
+// RawWidth returns the full sensor width before any processing.
+func (r *RAW) RawWidth() int {
+	return libraw.Libraw_get_raw_width(r.data)
+}
+
+// RawHeight returns the full sensor height before any processing.
+func (r *RAW) RawHeight() int {
+	return libraw.Libraw_get_raw_height(r.data)
+}
+
+// XMP returns the raw XMP packet bytes embedded in the file, or nil if absent.
+func (r *RAW) XMP() []byte {
+	return libraw.IParams_xmpdata(libraw.Libraw_get_iparams(r.data))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// METADATA
+
+// Metadata returns key/value pairs for camera info and shooting parameters.
+// Keys follow XMP namespace conventions (tiff:Make, exif:ISOSpeedRatings, etc.)
+// and implement the media.Metadata interface.
+func (r *RAW) Metadata() []media.Metadata {
+	return newMetadata(r)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// THUMBNAIL
+
+// Thumbnail extracts and decodes the embedded preview image. This is fast
+// since the thumbnail is pre-rendered inside the RAW file.
+func (r *RAW) Thumbnail() (image.Image, error) {
+	data, format, w, h, err := r.thumbnailRaw()
+	if err != nil {
+		return nil, err
+	}
+	switch format {
+	case libraw.THUMBNAIL_JPEG:
+		img, _, err := image.Decode(bytes.NewReader(data))
+		return img, err
+	case libraw.THUMBNAIL_BITMAP:
+		return bitmapToImage(data, w, h, 3, 8), nil
+	case libraw.THUMBNAIL_BITMAP16:
+		return bitmapToImage(data, w, h, 3, 16), nil
+	default:
+		return nil, media.ErrNotImplemented.Withf("thumbnail format %v", format)
+	}
+}
+
+// ThumbnailBytes returns the raw thumbnail bytes without decoding. For JPEG
+// thumbnails (the common case) this can be passed directly to exif.Parse to
+// extract embedded EXIF metadata.
+func (r *RAW) ThumbnailBytes() ([]byte, error) {
+	data, _, _, _, err := r.thumbnailRaw()
+	return data, err
+}
+
+func (r *RAW) thumbnailRaw() ([]byte, libraw.ThumbnailFormat, int, int, error) {
+	if rc := libraw.Libraw_unpack_thumb(r.data); rc != 0 {
+		return nil, libraw.THUMBNAIL_UNKNOWN, 0, 0, media.ErrInternalError.With(libraw.Libraw_strerror(rc))
+	}
+	thumb := libraw.Libraw_get_thumbnail(r.data)
+	data := libraw.Thumbnail_data(thumb)
+	if len(data) == 0 {
+		return nil, libraw.THUMBNAIL_UNKNOWN, 0, 0, media.ErrNotFound.With("no thumbnail data")
+	}
+	return data,
+		libraw.Thumbnail_format(thumb),
+		int(libraw.Thumbnail_width(thumb)),
+		int(libraw.Thumbnail_height(thumb)),
+		nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// IMAGE
+
+// Image demosaics and returns the full-resolution image. This is a slow
+// operation; use Thumbnail for quick previews.
+func (r *RAW) Image() (image.Image, error) {
+	if rc := libraw.Libraw_unpack(r.data); rc != 0 {
+		return nil, media.ErrInternalError.With(libraw.Libraw_strerror(rc))
+	}
+	if rc := libraw.Libraw_dcraw_process(r.data); rc != 0 {
+		return nil, media.ErrInternalError.With(libraw.Libraw_strerror(rc))
+	}
+	img, rc := libraw.Libraw_dcraw_make_mem_image(r.data)
+	if img == nil || rc != 0 {
+		return nil, media.ErrInternalError.With(libraw.Libraw_strerror(rc))
+	}
+	defer libraw.Libraw_dcraw_clear_mem(img)
+
+	data := libraw.ProcessedImage_data(img)
+	switch libraw.ProcessedImage_type(img) {
+	case libraw.IMAGE_JPEG:
+		goimg, _, err := image.Decode(bytes.NewReader(data))
+		return goimg, err
+	case libraw.IMAGE_BITMAP:
+		return bitmapToImage(data,
+			int(libraw.ProcessedImage_width(img)),
+			int(libraw.ProcessedImage_height(img)),
+			int(libraw.ProcessedImage_colors(img)),
+			int(libraw.ProcessedImage_bits(img))), nil
+	default:
+		return nil, media.ErrNotImplemented.Withf("image format %v", libraw.ProcessedImage_type(img))
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PRIVATE
+
+// bitmapToImage converts libraw's interleaved RGB bitmap to image.Image.
+// Libraw stores 16-bit values in little-endian host byte order.
+func bitmapToImage(data []byte, width, height, colors, bits int) image.Image {
+	if bits <= 8 {
+		img := image.NewNRGBA(image.Rect(0, 0, width, height))
+		for y := 0; y < height; y++ {
+			for x := 0; x < width; x++ {
+				off := (y*width + x) * colors
+				var rv, gv, bv uint8
+				switch {
+				case colors >= 3:
+					rv, gv, bv = data[off], data[off+1], data[off+2]
+				case colors == 1:
+					rv, gv, bv = data[off], data[off], data[off]
+				}
+				img.SetNRGBA(x, y, color.NRGBA{R: rv, G: gv, B: bv, A: 255})
+			}
+		}
+		return img
+	}
+	img := image.NewNRGBA64(image.Rect(0, 0, width, height))
+	stride := colors * 2
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			off := (y*width + x) * stride
+			var rv, gv, bv uint16
+			switch {
+			case colors >= 3:
+				rv = binary.LittleEndian.Uint16(data[off:])
+				gv = binary.LittleEndian.Uint16(data[off+2:])
+				bv = binary.LittleEndian.Uint16(data[off+4:])
+			case colors == 1:
+				rv = binary.LittleEndian.Uint16(data[off:])
+				gv, bv = rv, rv
+			}
+			img.SetNRGBA64(x, y, color.NRGBA64{R: rv, G: gv, B: bv, A: 0xffff})
+		}
+	}
+	return img
+}

--- a/pkg/raw/raw_test.go
+++ b/pkg/raw/raw_test.go
@@ -1,0 +1,208 @@
+package raw_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/mutablelogic/go-media/pkg/raw"
+)
+
+const testRAW = "../../etc/test/RAW_OLYMPUS_E3.ORF"
+
+////////////////////////////////////////////////////////////////////////////////
+// OPEN / READ / PARSE
+
+func Test_raw_000(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+}
+
+func Test_raw_001(t *testing.T) {
+	_, err := raw.Open("/does/not/exist.orf")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	t.Log(err)
+}
+
+func Test_raw_002(t *testing.T) {
+	buf, err := os.ReadFile(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := raw.Parse(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+}
+
+func Test_raw_003(t *testing.T) {
+	f, err := os.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	r, err := raw.Read(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ACCESSORS
+
+func Test_raw_010(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	t.Logf("make=%q model=%q software=%q", r.Make(), r.Model(), r.Software())
+	if r.Make() == "" {
+		t.Error("expected non-empty make")
+	}
+	if r.Model() == "" {
+		t.Error("expected non-empty model")
+	}
+}
+
+func Test_raw_011(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	t.Logf("iso=%.0f shutter=%v aperture=%.1f focal_len=%.0fmm",
+		r.ISOSpeed(), r.Shutter(), r.Aperture(), r.FocalLength())
+	t.Logf("timestamp=%v", r.Timestamp())
+}
+
+func Test_raw_012(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	t.Logf("raw=%dx%d image=%dx%d", r.RawWidth(), r.RawHeight(), r.Width(), r.Height())
+	if r.RawWidth() == 0 || r.RawHeight() == 0 {
+		t.Error("expected non-zero raw dimensions")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// METADATA
+
+func Test_raw_020(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	meta := r.Metadata()
+	if len(meta) == 0 {
+		t.Fatal("expected at least one metadata entry")
+	}
+	for _, m := range meta {
+		t.Logf("key=%q value=%q typed=%T(%v)", m.Key(), m.Value(), m.Any(), m.Any())
+	}
+}
+
+func Test_raw_021(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	for _, m := range r.Metadata() {
+		data, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("key=%q: %v", m.Key(), err)
+		}
+		t.Log(string(data))
+	}
+}
+
+func Test_raw_022(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	xmp := r.XMP()
+	if xmp != nil {
+		t.Logf("xmp length=%d bytes", len(xmp))
+	} else {
+		t.Log("no embedded XMP")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// THUMBNAIL
+
+func Test_raw_030(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	img, err := r.Thumbnail()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bounds := img.Bounds()
+	t.Logf("thumbnail size=%dx%d", bounds.Dx(), bounds.Dy())
+	if bounds.Dx() == 0 || bounds.Dy() == 0 {
+		t.Error("expected non-zero thumbnail dimensions")
+	}
+}
+
+func Test_raw_031(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	data, err := r.ThumbnailBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty thumbnail bytes")
+	}
+	t.Logf("thumbnail bytes=%d", len(data))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FULL IMAGE
+
+func Test_raw_040(t *testing.T) {
+	r, err := raw.Open(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	img, err := r.Image()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bounds := img.Bounds()
+	t.Logf("image size=%dx%d", bounds.Dx(), bounds.Dy())
+	if bounds.Dx() == 0 || bounds.Dy() == 0 {
+		t.Error("expected non-zero image dimensions")
+	}
+}

--- a/pkg/raw/type.go
+++ b/pkg/raw/type.go
@@ -1,0 +1,87 @@
+package raw
+
+import "mime"
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// rawTypes maps RAW camera file extensions to their MIME types.
+// All use the image/x-* convention; IANA has no official registrations for
+// most proprietary RAW formats.
+var rawTypes = map[string]string{
+	// Adobe / generic
+	".dng": "image/x-adobe-dng", // Canon, Leica, Ricoh, DJI, Google Pixel, …
+
+	// Canon
+	".cr2": "image/x-canon-cr2",
+	".cr3": "image/x-canon-cr3",
+	".crw": "image/x-canon-crw",
+
+	// Nikon
+	".nef": "image/x-nikon-nef",
+	".nrw": "image/x-nikon-nrw",
+
+	// Sony
+	".arw": "image/x-sony-arw",
+	".srf": "image/x-sony-srf",
+	".sr2": "image/x-sony-sr2",
+
+	// Olympus
+	".orf": "image/x-olympus-orf",
+
+	// Panasonic
+	".rw2": "image/x-panasonic-rw2",
+
+	// Fujifilm
+	".raf": "image/x-fuji-raf",
+
+	// Pentax / Ricoh
+	".pef": "image/x-pentax-pef",
+
+	// Leica
+	".rwl": "image/x-leica-rwl",
+
+	// Sigma
+	".x3f": "image/x-sigma-x3f",
+
+	// Samsung
+	".srw": "image/x-samsung-srw",
+
+	// Minolta / Konica Minolta
+	".mrw": "image/x-minolta-mrw",
+
+	// Epson
+	".erf": "image/x-epson-erf",
+
+	// Kodak
+	".dcr": "image/x-kodak-dcr",
+	".kdc": "image/x-kodak-kdc",
+
+	// Mamiya
+	".mef": "image/x-mamiya-mef",
+
+	// Hasselblad
+	".3fr": "image/x-hasselblad-3fr",
+	".fff": "image/x-hasselblad-fff",
+
+	// Phase One
+	".iiq": "image/x-phaseone-iiq",
+
+	// Leaf
+	".mos": "image/x-leaf-mos",
+
+	// Casio
+	".bay": "image/x-casio-bay",
+
+	// Generic / ambiguous (Contax, Panasonic, others)
+	".raw": "image/x-raw",
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+func init() {
+	for ext, typ := range rawTypes {
+		_ = mime.AddExtensionType(ext, typ)
+	}
+}

--- a/pkg/xmp/decoder.go
+++ b/pkg/xmp/decoder.go
@@ -1,0 +1,513 @@
+package xmp
+
+import (
+	"encoding/xml"
+	"io"
+	"strings"
+
+	media "github.com/mutablelogic/go-media"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// CONSTANTS
+
+const (
+	nsRDF   = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	nsXML   = "http://www.w3.org/XML/1998/namespace"
+	nsXMeta = "adobe:ns:meta/"
+
+	maxFileSize     = 1 << 20 // 1 MiB
+	maxNestingDepth = 64
+)
+
+// knownPrefixes maps well-known XMP namespace URIs to their conventional prefix.
+var knownPrefixes = map[string]string{
+	nsRDF:   "rdf",
+	nsXMeta: "x",
+	"http://purl.org/dc/elements/1.1/":               "dc",
+	"http://ns.adobe.com/xap/1.0/":                   "xmp",
+	"http://ns.adobe.com/xap/1.0/mm/":                "xmpMM",
+	"http://ns.adobe.com/xap/1.0/rights/":            "xmpRights",
+	"http://ns.adobe.com/xap/1.0/bj/":                "xmpBJ",
+	"http://ns.adobe.com/xap/1.0/t/pg/":              "xmpTPg",
+	"http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/":    "Iptc4xmpCore",
+	"http://ns.adobe.com/photoshop/1.0/":             "photoshop",
+	"http://ns.adobe.com/exif/1.0/":                  "exif",
+	"http://ns.adobe.com/exif/1.0/aux/":              "aux",
+	"http://ns.adobe.com/tiff/1.0/":                  "tiff",
+	"http://ns.adobe.com/camera-raw-settings/1.0/":   "crs",
+	"http://ns.adobe.com/xap/1.0/sType/ResourceRef#": "stRef",
+	"http://ns.adobe.com/xap/1.0/sType/Version#":     "stVer",
+	"http://ns.adobe.com/xap/1.0/sType/Font#":        "stFnt",
+	"http://ns.adobe.com/xap/1.0/sType/Dimensions#":  "stDim",
+	"http://ns.adobe.com/xap/1.0/sType/ResourceEvent#": "stEvt",
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type xmpDecoder struct {
+	d     *xml.Decoder
+	ns    map[string]string // URI → prefix (built up during parsing)
+	depth int               // current XML element nesting depth
+}
+
+// limitedReader returns an error (not io.EOF) when n bytes have been read,
+// so that xml.Decoder propagates the violation rather than treating it as a
+// clean end-of-file.
+type limitedReader struct {
+	r io.Reader
+	n int64
+}
+
+func (lr *limitedReader) Read(p []byte) (int, error) {
+	if lr.n <= 0 {
+		return 0, media.ErrBadParameter.Withf("XMP document exceeds %d byte size limit", maxFileSize)
+	}
+	if int64(len(p)) > lr.n {
+		p = p[:lr.n]
+	}
+	n, err := lr.r.Read(p)
+	lr.n -= int64(n)
+	return n, err
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ENTRY POINT
+
+func decode(r io.Reader) (*XMP, error) {
+	d := &xmpDecoder{
+		d:  xml.NewDecoder(&limitedReader{r: r, n: maxFileSize}),
+		ns: make(map[string]string),
+	}
+	return d.decode()
+}
+
+func (d *xmpDecoder) decode() (*XMP, error) {
+	for {
+		tok, err := d.token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		se, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+		d.collectNS(se.Attr)
+		if se.Name.Space == nsRDF && se.Name.Local == "RDF" {
+			return d.decodeRDF()
+		}
+		// x:xmpmeta or other wrappers — keep descending
+	}
+	return nil, media.ErrBadParameter.With("no XMP/RDF data found")
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// RDF
+
+func (d *xmpDecoder) decodeRDF() (*XMP, error) {
+	xmp := &XMP{}
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			d.collectNS(t.Attr)
+			if t.Name.Space == nsRDF && t.Name.Local == "Description" {
+				if err := d.decodeDescription(xmp, t); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := d.skip(); err != nil {
+					return nil, err
+				}
+			}
+		case xml.EndElement:
+			return xmp, nil
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// rdf:Description
+
+func (d *xmpDecoder) decodeDescription(xmp *XMP, start xml.StartElement) error {
+	d.collectNS(start.Attr)
+
+	// Inline attributes on rdf:Description are Simple properties
+	for _, attr := range start.Attr {
+		switch {
+		case attr.Name.Space == nsRDF && attr.Name.Local == "about":
+			xmp.about = attr.Value
+		case attr.Name.Space == "xmlns", attr.Name.Space == nsXML, attr.Name.Space == "":
+			// namespace declaration or plain attribute — skip
+		default:
+			xmp.items = append(xmp.items, &Item{
+				ns:     attr.Name.Space,
+				prefix: d.prefixFor(attr.Name.Space),
+				name:   attr.Name.Local,
+				kind:   Simple,
+				value:  attr.Value,
+			})
+		}
+	}
+
+	// Child elements are properties
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			item, err := d.decodeProperty(t)
+			if err != nil {
+				return err
+			}
+			if item != nil {
+				xmp.items = append(xmp.items, item)
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Property elements
+
+func (d *xmpDecoder) decodeProperty(start xml.StartElement) (*Item, error) {
+	d.collectNS(start.Attr)
+	prefix := d.prefixFor(start.Name.Space)
+
+	// rdf:resource attribute → Simple URI value
+	for _, attr := range start.Attr {
+		if attr.Name.Space == nsRDF && attr.Name.Local == "resource" {
+			if err := d.consumeEnd(start.Name); err != nil {
+				return nil, err
+			}
+			return &Item{
+				ns: start.Name.Space, prefix: prefix,
+				name: start.Name.Local, kind: Simple, value: attr.Value,
+			}, nil
+		}
+		// rdf:parseType="Resource" is a shorthand for an inline struct
+		if attr.Name.Space == nsRDF && attr.Name.Local == "parseType" && attr.Value == "Resource" {
+			fields, err := d.decodeStructFields(start)
+			if err != nil {
+				return nil, err
+			}
+			return &Item{
+				ns: start.Name.Space, prefix: prefix,
+				name: start.Name.Local, kind: Struct, items: fields,
+			}, nil
+		}
+	}
+
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			s := strings.TrimSpace(string(t))
+			if s == "" {
+				continue
+			}
+			// Text content → Simple
+			if err := d.consumeEnd(start.Name); err != nil {
+				return nil, err
+			}
+			return &Item{
+				ns: start.Name.Space, prefix: prefix,
+				name: start.Name.Local, kind: Simple,
+				lang: xmlLang(start.Attr), value: s,
+			}, nil
+
+		case xml.StartElement:
+			if t.Name.Space == nsRDF {
+				var (
+					children []*Item
+					kind     Kind
+					decErr   error
+				)
+				switch t.Name.Local {
+				case "Bag":
+					kind, children, decErr = Bag, nil, nil
+					children, decErr = d.decodeListItems()
+				case "Seq":
+					kind, children, decErr = Seq, nil, nil
+					children, decErr = d.decodeListItems()
+				case "Alt":
+					kind, children, decErr = Alt, nil, nil
+					children, decErr = d.decodeListItems()
+				case "Description":
+					kind = Struct
+					children, decErr = d.decodeStructFields(t)
+				default:
+					if err := d.skip(); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				if decErr != nil {
+					return nil, decErr
+				}
+				if err := d.consumeEnd(start.Name); err != nil {
+					return nil, err
+				}
+				return &Item{
+					ns: start.Name.Space, prefix: prefix,
+					name: start.Name.Local, kind: kind, items: children,
+				}, nil
+			}
+			// Unknown nested element — skip and keep looking
+			if err := d.skip(); err != nil {
+				return nil, err
+			}
+
+		case xml.EndElement:
+			// Self-closing or empty element → empty Simple
+			return &Item{
+				ns: start.Name.Space, prefix: prefix,
+				name: start.Name.Local, kind: Simple, value: "",
+			}, nil
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// rdf:Bag / rdf:Seq / rdf:Alt  (reads rdf:li items until container end)
+
+func (d *xmpDecoder) decodeListItems() ([]*Item, error) {
+	var items []*Item
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Space == nsRDF && t.Name.Local == "li" {
+				item, err := d.decodeLi(t)
+				if err != nil {
+					return nil, err
+				}
+				if item != nil {
+					items = append(items, item)
+				}
+			} else {
+				if err := d.skip(); err != nil {
+					return nil, err
+				}
+			}
+		case xml.EndElement:
+			return items, nil
+		}
+	}
+}
+
+func (d *xmpDecoder) decodeLi(start xml.StartElement) (*Item, error) {
+	lang := xmlLang(start.Attr)
+
+	// rdf:resource / rdf:parseType="Resource" on rdf:li
+	for _, attr := range start.Attr {
+		if attr.Name.Space != nsRDF {
+			continue
+		}
+		if attr.Name.Local == "resource" {
+			if err := d.consumeEnd(start.Name); err != nil {
+				return nil, err
+			}
+			return &Item{ns: nsRDF, prefix: "rdf", name: "li", kind: Simple, lang: lang, value: attr.Value}, nil
+		}
+		if attr.Name.Local == "parseType" && attr.Value == "Resource" {
+			// Children are inline struct fields, no wrapping rdf:Description
+			fields, err := d.decodeStructFields(start)
+			if err != nil {
+				return nil, err
+			}
+			return &Item{ns: nsRDF, prefix: "rdf", name: "li", kind: Struct, lang: lang, items: fields}, nil
+		}
+	}
+
+	var buf strings.Builder
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			buf.Write(t)
+		case xml.StartElement:
+			// Struct inside an li (rdf:Description)
+			if t.Name.Space == nsRDF && t.Name.Local == "Description" {
+				fields, err := d.decodeStructFields(t)
+				if err != nil {
+					return nil, err
+				}
+				if err := d.consumeEnd(start.Name); err != nil {
+					return nil, err
+				}
+				return &Item{ns: nsRDF, prefix: "rdf", name: "li", kind: Struct, lang: lang, items: fields}, nil
+			}
+			if err := d.skip(); err != nil {
+				return nil, err
+			}
+		case xml.EndElement:
+			return &Item{
+				ns: nsRDF, prefix: "rdf", name: "li", kind: Simple,
+				lang: lang, value: strings.TrimSpace(buf.String()),
+			}, nil
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// rdf:Description inside a property (struct value)
+
+func (d *xmpDecoder) decodeStructFields(start xml.StartElement) ([]*Item, error) {
+	d.collectNS(start.Attr)
+	var fields []*Item
+
+	// Inline attributes are struct fields
+	for _, attr := range start.Attr {
+		switch {
+		case attr.Name.Space == "xmlns", attr.Name.Space == nsRDF,
+			attr.Name.Space == nsXML, attr.Name.Space == "":
+			// skip namespace declarations and rdf: control attributes
+		default:
+			fields = append(fields, &Item{
+				ns:     attr.Name.Space,
+				prefix: d.prefixFor(attr.Name.Space),
+				name:   attr.Name.Local,
+				kind:   Simple,
+				value:  attr.Value,
+			})
+		}
+	}
+
+	// Child elements are struct fields
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return nil, err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			item, err := d.decodeProperty(t)
+			if err != nil {
+				return nil, err
+			}
+			if item != nil {
+				fields = append(fields, item)
+			}
+		case xml.EndElement:
+			return fields, nil
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// HELPERS
+
+// token wraps d.d.Token(), tracking nesting depth and enforcing the limit.
+func (d *xmpDecoder) token() (xml.Token, error) {
+	tok, err := d.d.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch tok.(type) {
+	case xml.StartElement:
+		d.depth++
+		if d.depth > maxNestingDepth {
+			return nil, media.ErrBadParameter.Withf("XMP nesting depth exceeds %d", maxNestingDepth)
+		}
+	case xml.EndElement:
+		d.depth--
+	}
+	return tok, nil
+}
+
+// skip consumes the children and closing element of a StartElement that has
+// already been read. Uses token() so that d.depth stays accurate.
+func (d *xmpDecoder) skip() error {
+	depth := 1
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return err
+		}
+		switch tok.(type) {
+		case xml.StartElement:
+			depth++
+		case xml.EndElement:
+			depth--
+			if depth == 0 {
+				return nil
+			}
+		}
+	}
+}
+
+// collectNS extracts xmlns: declarations from attrs into d.ns.
+func (d *xmpDecoder) collectNS(attrs []xml.Attr) {
+	for _, attr := range attrs {
+		if attr.Name.Space == "xmlns" && attr.Name.Local != "" {
+			d.ns[attr.Value] = attr.Name.Local
+		}
+	}
+}
+
+// prefixFor returns the preferred prefix for a namespace URI.
+func (d *xmpDecoder) prefixFor(uri string) string {
+	if p, ok := d.ns[uri]; ok {
+		return p
+	}
+	if p, ok := knownPrefixes[uri]; ok {
+		return p
+	}
+	return ""
+}
+
+// consumeEnd discards tokens until the matching end element for name is found.
+// Uses token() to keep d.depth current.
+func (d *xmpDecoder) consumeEnd(name xml.Name) error {
+	sameNameDepth := 0
+	for {
+		tok, err := d.token()
+		if err != nil {
+			return err
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name == name {
+				sameNameDepth++
+			}
+		case xml.EndElement:
+			if t.Name == name {
+				if sameNameDepth == 0 {
+					return nil
+				}
+				sameNameDepth--
+			}
+		}
+	}
+}
+
+// xmlLang extracts the xml:lang attribute value from attrs.
+func xmlLang(attrs []xml.Attr) string {
+	for _, attr := range attrs {
+		if attr.Name.Space == nsXML && attr.Name.Local == "lang" {
+			return attr.Value
+		}
+	}
+	return ""
+}

--- a/pkg/xmp/doc.go
+++ b/pkg/xmp/doc.go
@@ -1,0 +1,5 @@
+// Package xmp provides XMP (Extensible Metadata Platform) encoding and decoding.
+// XMP stores structured metadata as RDF/XML, organized into namespaced properties
+// that can be simple strings, ordered or unordered arrays, localized alternatives,
+// or nested structures.
+package xmp

--- a/pkg/xmp/encoder.go
+++ b/pkg/xmp/encoder.go
@@ -1,0 +1,164 @@
+package xmp
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// CONSTANTS
+
+const (
+	xpacketBegin = "<?xpacket begin=\"\xef\xbb\xbf\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n"
+	xpacketEnd   = "\n<?xpacket end=\"w\"?>\n"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type xmpEncoder struct {
+	w *bufio.Writer
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ENTRY POINT
+
+func encode(w io.Writer, x *XMP) error {
+	enc := &xmpEncoder{w: bufio.NewWriter(w)}
+	if err := enc.encode(x); err != nil {
+		return err
+	}
+	return enc.w.Flush()
+}
+
+func (e *xmpEncoder) encode(x *XMP) error {
+	// Collect namespace declarations needed for all items
+	nsMap := make(map[string]string) // URI → prefix
+	for _, it := range x.items {
+		collectNS(it, nsMap)
+	}
+
+	e.w.WriteString(xpacketBegin)
+	e.w.WriteString("<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n")
+	e.w.WriteString("  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n")
+
+	// rdf:Description opener with rdf:about and namespace declarations
+	fmt.Fprintf(e.w, "    <rdf:Description rdf:about=%q", x.about)
+	uris := make([]string, 0, len(nsMap))
+	for uri := range nsMap {
+		uris = append(uris, uri)
+	}
+	sort.Strings(uris)
+	for _, uri := range uris {
+		fmt.Fprintf(e.w, "\n        xmlns:%s=%q", nsMap[uri], uri)
+	}
+
+	if len(x.items) == 0 {
+		e.w.WriteString("/>\n")
+	} else {
+		e.w.WriteString(">\n")
+		for _, it := range x.items {
+			if err := e.writeItem(it, "      "); err != nil {
+				return err
+			}
+		}
+		e.w.WriteString("    </rdf:Description>\n")
+	}
+
+	e.w.WriteString("  </rdf:RDF>\n")
+	e.w.WriteString("</x:xmpmeta>")
+	e.w.WriteString(xpacketEnd)
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ITEM WRITING
+
+func (e *xmpEncoder) writeItem(it *Item, indent string) error {
+	tag := itemTag(it)
+
+	switch it.kind {
+	case Simple:
+		if it.lang != "" {
+			fmt.Fprintf(e.w, "%s<%s xml:lang=%q>%s</%s>\n",
+				indent, tag, it.lang, escapeXML(it.value), tag)
+		} else {
+			fmt.Fprintf(e.w, "%s<%s>%s</%s>\n",
+				indent, tag, escapeXML(it.value), tag)
+		}
+
+	case Bag:
+		fmt.Fprintf(e.w, "%s<%s>\n%s  <rdf:Bag>\n", indent, tag, indent)
+		for _, child := range it.items {
+			e.writeLi(child, indent+"    ")
+		}
+		fmt.Fprintf(e.w, "%s  </rdf:Bag>\n%s</%s>\n", indent, indent, tag)
+
+	case Seq:
+		fmt.Fprintf(e.w, "%s<%s>\n%s  <rdf:Seq>\n", indent, tag, indent)
+		for _, child := range it.items {
+			e.writeLi(child, indent+"    ")
+		}
+		fmt.Fprintf(e.w, "%s  </rdf:Seq>\n%s</%s>\n", indent, indent, tag)
+
+	case Alt:
+		fmt.Fprintf(e.w, "%s<%s>\n%s  <rdf:Alt>\n", indent, tag, indent)
+		for _, child := range it.items {
+			e.writeLi(child, indent+"    ")
+		}
+		fmt.Fprintf(e.w, "%s  </rdf:Alt>\n%s</%s>\n", indent, indent, tag)
+
+	case Struct:
+		fmt.Fprintf(e.w, "%s<%s>\n%s  <rdf:Description>\n", indent, tag, indent)
+		for _, field := range it.items {
+			if err := e.writeItem(field, indent+"    "); err != nil {
+				return err
+			}
+		}
+		fmt.Fprintf(e.w, "%s  </rdf:Description>\n%s</%s>\n", indent, indent, tag)
+	}
+	return nil
+}
+
+func (e *xmpEncoder) writeLi(it *Item, indent string) {
+	if it.lang != "" {
+		fmt.Fprintf(e.w, "%s<rdf:li xml:lang=%q>%s</rdf:li>\n",
+			indent, it.lang, escapeXML(it.value))
+	} else {
+		fmt.Fprintf(e.w, "%s<rdf:li>%s</rdf:li>\n",
+			indent, escapeXML(it.value))
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// HELPERS
+
+// itemTag returns "prefix:name" or just "name" if no prefix.
+func itemTag(it *Item) string {
+	if it.prefix == "" {
+		return it.name
+	}
+	return it.prefix + ":" + it.name
+}
+
+// collectNS recursively gathers namespace URI→prefix mappings from item and
+// all its descendants, skipping the RDF namespace (declared at the RDF level).
+func collectNS(it *Item, ns map[string]string) {
+	if it.ns != "" && it.ns != nsRDF && it.prefix != "" {
+		ns[it.ns] = it.prefix
+	}
+	for _, child := range it.items {
+		collectNS(child, ns)
+	}
+}
+
+// escapeXML returns s with XML special characters escaped.
+func escapeXML(s string) string {
+	var buf strings.Builder
+	xml.EscapeText(&buf, []byte(s)) //nolint:errcheck // strings.Builder never errors
+	return buf.String()
+}

--- a/pkg/xmp/item.go
+++ b/pkg/xmp/item.go
@@ -1,0 +1,217 @@
+package xmp
+
+import (
+	"encoding/json"
+	"image"
+	"strings"
+
+	// Packages
+	media "github.com/mutablelogic/go-media"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// Kind describes the shape of an XMP property value.
+type Kind uint8
+
+const (
+	Simple Kind = iota // a single string (optionally language-tagged)
+	Bag                // unordered set of strings
+	Seq                // ordered sequence of strings
+	Alt                // localized alternatives keyed by xml:lang
+	Struct             // nested record with named fields
+)
+
+// Item represents a single XMP metadata property and implements media.Metadata.
+type Item struct {
+	ns     string // namespace URI
+	prefix string // preferred namespace prefix
+	name   string // local property name
+	kind   Kind
+	lang   string  // xml:lang qualifier (Simple leaf values)
+	value  string  // Simple leaf value
+	items  []*Item // Bag/Seq/Alt members or Struct fields
+}
+
+var _ media.Metadata = (*Item)(nil)
+
+////////////////////////////////////////////////////////////////////////////////
+// CONSTRUCTORS
+
+// NewItem creates a Simple property.
+func NewItem(ns, prefix, name, value string) *Item {
+	return &Item{ns: ns, prefix: prefix, name: name, kind: Simple, value: value}
+}
+
+// NewItemLang creates a Simple property with an xml:lang qualifier.
+func NewItemLang(ns, prefix, name, lang, value string) *Item {
+	return &Item{ns: ns, prefix: prefix, name: name, kind: Simple, lang: lang, value: value}
+}
+
+// NewBag creates an unordered-set property.
+func NewBag(ns, prefix, name string, values ...string) *Item {
+	return newListItem(ns, prefix, name, Bag, values)
+}
+
+// NewSeq creates an ordered-sequence property.
+func NewSeq(ns, prefix, name string, values ...string) *Item {
+	return newListItem(ns, prefix, name, Seq, values)
+}
+
+// NewAlt creates an alternatives property. langValues is a sequence of [lang, value]
+// pairs; use "x-default" as the lang for the canonical value.
+func NewAlt(ns, prefix, name string, langValues ...[2]string) *Item {
+	children := make([]*Item, len(langValues))
+	for i, lv := range langValues {
+		children[i] = &Item{ns: nsRDF, prefix: "rdf", name: "li", kind: Simple, lang: lv[0], value: lv[1]}
+	}
+	return &Item{ns: ns, prefix: prefix, name: name, kind: Alt, items: children}
+}
+
+// NewStruct creates a structured property with named fields.
+func NewStruct(ns, prefix, name string, fields ...*Item) *Item {
+	return &Item{ns: ns, prefix: prefix, name: name, kind: Struct, items: fields}
+}
+
+func newListItem(ns, prefix, name string, kind Kind, values []string) *Item {
+	children := make([]*Item, len(values))
+	for i, v := range values {
+		children[i] = &Item{ns: nsRDF, prefix: "rdf", name: "li", kind: Simple, value: v}
+	}
+	return &Item{ns: ns, prefix: prefix, name: name, kind: kind, items: children}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ACCESSORS
+
+// NS returns the namespace URI.
+func (it *Item) NS() string { return it.ns }
+
+// Prefix returns the preferred namespace prefix.
+func (it *Item) Prefix() string { return it.prefix }
+
+// LocalName returns the local property name.
+func (it *Item) LocalName() string { return it.name }
+
+// ItemKind returns the value kind.
+func (it *Item) ItemKind() Kind { return it.kind }
+
+// Lang returns the xml:lang qualifier (non-empty for Simple items with a language tag
+// and for Alt child items).
+func (it *Item) Lang() string { return it.lang }
+
+// Items returns child items: members of Bag/Seq/Alt, or fields of a Struct.
+func (it *Item) Items() []*Item { return it.items }
+
+////////////////////////////////////////////////////////////////////////////////
+// media.Metadata
+
+// Key returns "prefix:name" (implements media.Metadata).
+func (it *Item) Key() string {
+	if it.prefix == "" {
+		return it.name
+	}
+	return it.prefix + ":" + it.name
+}
+
+// Value returns the string value (implements media.Metadata).
+// For Bag/Seq, values are joined with "; ".
+// For Alt, the "x-default" value is returned, falling back to the first entry.
+// For Struct, an empty string is returned.
+func (it *Item) Value() string {
+	switch it.kind {
+	case Simple:
+		return it.value
+	case Bag, Seq:
+		parts := make([]string, 0, len(it.items))
+		for _, child := range it.items {
+			parts = append(parts, child.value)
+		}
+		return strings.Join(parts, "; ")
+	case Alt:
+		for _, child := range it.items {
+			if child.lang == "x-default" {
+				return child.value
+			}
+		}
+		if len(it.items) > 0 {
+			return it.items[0].value
+		}
+	}
+	return ""
+}
+
+// Bytes returns nil — XMP properties are text-only (implements media.Metadata).
+func (it *Item) Bytes() []byte { return nil }
+
+// Image returns nil (implements media.Metadata).
+func (it *Item) Image() image.Image { return nil }
+
+// Any returns the property value as an appropriate Go type (implements media.Metadata):
+//   - Simple  → string
+//   - Bag/Seq → []string
+//   - Alt     → map[string]string  (lang → value)
+//   - Struct  → []*Item
+func (it *Item) Any() any {
+	switch it.kind {
+	case Simple:
+		return it.value
+	case Bag, Seq:
+		out := make([]string, len(it.items))
+		for i, child := range it.items {
+			out[i] = child.value
+		}
+		return out
+	case Alt:
+		out := make(map[string]string, len(it.items))
+		for _, child := range it.items {
+			out[child.lang] = child.value
+		}
+		return out
+	case Struct:
+		return it.items
+	}
+	return nil
+}
+
+// String returns "key=value".
+func (it *Item) String() string {
+	return it.Key() + "=" + it.Value()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (it *Item) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Key  string `json:"key"`
+		NS   string `json:"ns,omitempty"`
+		Kind string `json:"kind"`
+		Lang string `json:"lang,omitempty"`
+		Val  any    `json:"value"`
+	}{
+		Key:  it.Key(),
+		NS:   it.ns,
+		Kind: it.kind.String(),
+		Lang: it.lang,
+		Val:  it.Any(),
+	})
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Kind stringer
+
+func (k Kind) String() string {
+	switch k {
+	case Simple:
+		return "simple"
+	case Bag:
+		return "bag"
+	case Seq:
+		return "seq"
+	case Alt:
+		return "alt"
+	case Struct:
+		return "struct"
+	}
+	return "unknown"
+}

--- a/pkg/xmp/xmp.go
+++ b/pkg/xmp/xmp.go
@@ -1,0 +1,115 @@
+package xmp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// XMP holds a parsed XMP metadata document.
+type XMP struct {
+	about string  // rdf:about value (usually empty string)
+	items []*Item // top-level properties
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+// New returns an empty XMP document.
+func New() *XMP {
+	return &XMP{}
+}
+
+// Parse parses an XMP document from a byte slice.
+func Parse(data []byte) (*XMP, error) {
+	return Read(bytes.NewReader(data))
+}
+
+// Read parses an XMP document from r.
+func Read(r io.Reader) (*XMP, error) {
+	return decode(r)
+}
+
+// Write encodes the XMP document as an XMP/RDF/XML packet to w.
+func (x *XMP) Write(w io.Writer) error {
+	return encode(w, x)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+
+// Items returns all top-level metadata properties.
+func (x *XMP) Items() []*Item {
+	return x.items
+}
+
+// Get returns all items whose key equals key. The key may be "prefix:name" or
+// just the local name.
+func (x *XMP) Get(key string) []*Item {
+	var out []*Item
+	for _, it := range x.items {
+		if it.Key() == key || it.name == key {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
+// Add appends items to the document.
+func (x *XMP) Add(items ...*Item) {
+	x.items = append(x.items, items...)
+}
+
+// First returns the first item with a non-empty value from the first matching
+// key in the ordered list. This implements the priority-fallback pattern used
+// when the same semantic field can appear under multiple namespace prefixes,
+// e.g. x.First("photoshop:DateCreated", "exif:DateTimeOriginal", "xmp:CreateDate").
+func (x *XMP) First(keys ...string) *Item {
+	for _, key := range keys {
+		for _, it := range x.items {
+			if (it.Key() == key || it.name == key) && it.Value() != "" {
+				return it
+			}
+		}
+	}
+	return nil
+}
+
+// Delete removes all items matching key and returns the count removed.
+func (x *XMP) Delete(key string) int {
+	kept := x.items[:0]
+	n := 0
+	for _, it := range x.items {
+		if it.Key() == key || it.name == key {
+			n++
+		} else {
+			kept = append(kept, it)
+		}
+	}
+	x.items = kept
+	return n
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// STRINGIFY
+
+// String returns the document encoded as an XMP/XML string.
+func (x *XMP) String() string {
+	var buf bytes.Buffer
+	_ = x.Write(&buf)
+	return buf.String()
+}
+
+// MarshalJSON implements json.Marshaler.
+func (x *XMP) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		About string  `json:"about,omitempty"`
+		Items []*Item `json:"items"`
+	}{
+		About: x.about,
+		Items: x.items,
+	})
+}

--- a/pkg/xmp/xmp_test.go
+++ b/pkg/xmp/xmp_test.go
@@ -1,0 +1,581 @@
+package xmp_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mutablelogic/go-media/pkg/xmp"
+)
+
+const (
+	testXMP       = "../../etc/test/sample.xmp"
+	testXMPPDFx   = "../../etc/test/pdfx-xmp-example.xmp"
+	testXMPRandom = "../../etc/test/random-xmp-example.xmp"
+	testXMPBridge = "../../etc/test/bridge-2.xmp"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// PARSE / READ
+
+func Test_xmp_000(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(x.Items()) == 0 {
+		t.Fatal("expected at least one item")
+	}
+	t.Log(x)
+}
+
+func Test_xmp_001(t *testing.T) {
+	f, err := os.Open(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	x, err := xmp.Read(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(x.Items()) == 0 {
+		t.Fatal("expected at least one item")
+	}
+}
+
+func Test_xmp_002(t *testing.T) {
+	_, err := xmp.Parse([]byte("not xml"))
+	if err == nil {
+		t.Fatal("expected error for invalid XMP")
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ITEMS
+
+func Test_xmp_010(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, it := range x.Items() {
+		if it.Key() == "" {
+			t.Error("item has empty key")
+		}
+		t.Logf("kind=%-6s key=%-30s value=%q", it.ItemKind(), it.Key(), it.Value())
+	}
+}
+
+func Test_xmp_011(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// dc:title should be an Alt with x-default "Sample Image"
+	titles := x.Get("dc:title")
+	if len(titles) != 1 {
+		t.Fatalf("expected 1 dc:title, got %d", len(titles))
+	}
+	if titles[0].ItemKind() != xmp.Alt {
+		t.Errorf("dc:title: expected Alt kind, got %s", titles[0].ItemKind())
+	}
+	if got := titles[0].Value(); got != "Sample Image" {
+		t.Errorf("dc:title value: expected %q, got %q", "Sample Image", got)
+	}
+}
+
+func Test_xmp_012(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// dc:subject should be a Bag with 3 items
+	subjects := x.Get("dc:subject")
+	if len(subjects) != 1 {
+		t.Fatalf("expected 1 dc:subject, got %d", len(subjects))
+	}
+	if subjects[0].ItemKind() != xmp.Bag {
+		t.Errorf("dc:subject: expected Bag kind, got %s", subjects[0].ItemKind())
+	}
+	if n := len(subjects[0].Items()); n != 3 {
+		t.Errorf("dc:subject: expected 3 members, got %d", n)
+	}
+}
+
+func Test_xmp_013(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// dc:creator should be a Seq with 2 items
+	creators := x.Get("dc:creator")
+	if len(creators) != 1 {
+		t.Fatalf("expected 1 dc:creator, got %d", len(creators))
+	}
+	if creators[0].ItemKind() != xmp.Seq {
+		t.Errorf("dc:creator: expected Seq kind, got %s", creators[0].ItemKind())
+	}
+	if got, want := creators[0].Value(), "Jane Doe; John Smith"; got != want {
+		t.Errorf("dc:creator value: expected %q, got %q", want, got)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// GET / ADD / DELETE
+
+func Test_xmp_020(t *testing.T) {
+	x := xmp.New()
+	x.Add(xmp.NewItem("http://purl.org/dc/elements/1.1/", "dc", "format", "image/jpeg"))
+	x.Add(xmp.NewItem("http://purl.org/dc/elements/1.1/", "dc", "format", "image/png"))
+
+	if n := len(x.Get("dc:format")); n != 2 {
+		t.Fatalf("expected 2 items, got %d", n)
+	}
+	if removed := x.Delete("dc:format"); removed != 2 {
+		t.Errorf("Delete: expected 2 removed, got %d", removed)
+	}
+	if n := len(x.Items()); n != 0 {
+		t.Errorf("expected empty document, got %d items", n)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// JSON
+
+func Test_xmp_030(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(string(j))
+}
+
+func Test_xmp_031(t *testing.T) {
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, it := range x.Items() {
+		j, err := json.Marshal(it)
+		if err != nil {
+			t.Fatalf("item %q: %v", it.Key(), err)
+		}
+		t.Log(string(j))
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// ENCODE / ROUND-TRIP
+
+func Test_xmp_040(t *testing.T) {
+	x := xmp.New()
+	x.Add(xmp.NewItem("http://purl.org/dc/elements/1.1/", "dc", "format", "image/jpeg"))
+	x.Add(xmp.NewBag("http://purl.org/dc/elements/1.1/", "dc", "subject", "foo", "bar"))
+	x.Add(xmp.NewSeq("http://purl.org/dc/elements/1.1/", "dc", "creator", "Jane Doe"))
+	x.Add(xmp.NewAlt("http://purl.org/dc/elements/1.1/", "dc", "title",
+		[2]string{"x-default", "My Title"}, [2]string{"de", "Mein Titel"}))
+
+	var buf bytes.Buffer
+	if err := x.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+	t.Log(buf.String())
+}
+
+func Test_xmp_041(t *testing.T) {
+	// Round-trip: parse then re-encode
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := x.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-parse the encoded output
+	x2, err := xmp.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("re-parse failed: %v\nencoded:\n%s", err, buf.String())
+	}
+	if got, want := len(x2.Items()), len(x.Items()); got != want {
+		t.Errorf("round-trip item count: got %d, want %d", got, want)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// SECURITY GUARDS
+
+func Test_xmp_070(t *testing.T) {
+	// File exceeding 1 MiB should be rejected
+	big := make([]byte, 1<<20+1)
+	copy(big, []byte("<x:xmpmeta"))
+	_, err := xmp.Parse(big)
+	if err == nil {
+		t.Fatal("expected error for oversized document")
+	}
+	t.Log("oversized:", err)
+}
+
+func Test_xmp_071(t *testing.T) {
+	// Deeply nested XML should be rejected at maxNestingDepth
+	var sb strings.Builder
+	sb.WriteString(`<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="">`)
+	for i := 0; i < 70; i++ {
+		sb.WriteString(`<dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">`)
+	}
+	sb.WriteString("deep")
+	for i := 0; i < 70; i++ {
+		sb.WriteString(`</dc:title>`)
+	}
+	sb.WriteString(`</rdf:Description></rdf:RDF></x:xmpmeta>`)
+
+	_, err := xmp.Parse([]byte(sb.String()))
+	if err == nil {
+		t.Fatal("expected error for deeply nested document")
+	}
+	t.Log("deep nesting:", err)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// FIRST — priority-fallback lookup
+
+func Test_xmp_080(t *testing.T) {
+	x := xmp.New()
+	x.Add(xmp.NewItem("http://ns.adobe.com/xap/1.0/", "xmp", "CreateDate", "2024-01-15"))
+
+	// First key matches
+	it := x.First("photoshop:DateCreated", "xmp:CreateDate")
+	if it == nil {
+		t.Fatal("expected a result")
+	}
+	if got := it.Value(); got != "2024-01-15" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func Test_xmp_081(t *testing.T) {
+	x := xmp.New()
+	x.Add(xmp.NewItem("http://ns.adobe.com/xap/1.0/", "xmp", "CreateDate", "2024-01-15"))
+
+	// No key matches → nil
+	if got := x.First("photoshop:DateCreated", "exif:DateTimeOriginal"); got != nil {
+		t.Errorf("expected nil, got %q", got.Key())
+	}
+}
+
+func Test_xmp_082(t *testing.T) {
+	// First against real file: dc:title exists under first preference key
+	data, err := os.ReadFile(testXMP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	it := x.First("dc:title", "xmp:Title")
+	if it == nil {
+		t.Fatal("expected dc:title")
+	}
+	if got := it.Value(); got != "Sample Image" {
+		t.Errorf("got %q", got)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// PDFX EXAMPLE — multiple rdf:Description blocks, unknown namespaces, xpacket padding
+
+func Test_xmp_050(t *testing.T) {
+	data, err := os.ReadFile(testXMPPDFx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seven rdf:Description blocks should be merged into a flat item list
+	if n := len(x.Items()); n != 35 {
+		t.Errorf("expected 35 items from merged rdf:Description blocks, got %d", n)
+	}
+	for _, it := range x.Items() {
+		t.Logf("kind=%-6s key=%-40s value=%q", it.ItemKind(), it.Key(), it.Value())
+	}
+}
+
+func Test_xmp_051(t *testing.T) {
+	data, err := os.ReadFile(testXMPPDFx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unknown prism: namespace should survive with prefix intact
+	pubs := x.Get("prism:publicationName")
+	if len(pubs) != 1 {
+		t.Fatalf("expected 1 prism:publicationName, got %d", len(pubs))
+	}
+	if got := pubs[0].Value(); got != "Analytica Chimica Acta" {
+		t.Errorf("prism:publicationName: got %q", got)
+	}
+
+	// pdfx:CrossMarkDomains should be a Seq
+	domains := x.Get("pdfx:CrossMarkDomains")
+	if len(domains) != 1 {
+		t.Fatalf("expected 1 pdfx:CrossMarkDomains, got %d", len(domains))
+	}
+	if domains[0].ItemKind() != xmp.Seq {
+		t.Errorf("pdfx:CrossMarkDomains: expected Seq, got %s", domains[0].ItemKind())
+	}
+	if n := len(domains[0].Items()); n != 2 {
+		t.Errorf("pdfx:CrossMarkDomains: expected 2 members, got %d", n)
+	}
+}
+
+func Test_xmp_052(t *testing.T) {
+	// Round-trip pdfx file
+	data, err := os.ReadFile(testXMPPDFx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := x.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+	x2, err := xmp.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("re-parse failed: %v\nencoded:\n%s", err, buf.String())
+	}
+	if got, want := len(x2.Items()), len(x.Items()); got != want {
+		t.Errorf("round-trip item count: got %d, want %d", got, want)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// RANDOM EXAMPLE — no xpacket wrapper, old xap:/xapMM: prefix aliases
+
+func Test_xmp_060(t *testing.T) {
+	data, err := os.ReadFile(testXMPRandom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(x.Items()); n != 16 {
+		t.Errorf("expected 16 items, got %d", n)
+	}
+	for _, it := range x.Items() {
+		t.Logf("kind=%-6s key=%-40s value=%q", it.ItemKind(), it.Key(), it.Value())
+	}
+}
+
+func Test_xmp_061(t *testing.T) {
+	data, err := os.ReadFile(testXMPRandom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Old xap: prefix (same URI as xmp:) should be preserved as declared
+	dates := x.Get("xap:CreateDate")
+	if len(dates) != 1 {
+		t.Fatalf("expected 1 xap:CreateDate, got %d", len(dates))
+	}
+	if got := dates[0].Value(); got != "2008-09-16T08:19:40Z" {
+		t.Errorf("xap:CreateDate: got %q", got)
+	}
+
+	// Old xapMM: prefix (same URI as xmpMM:) should also be preserved
+	docIDs := x.Get("xapMM:DocumentID")
+	if len(docIDs) != 1 {
+		t.Fatalf("expected 1 xapMM:DocumentID, got %d", len(docIDs))
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BRIDGE EXAMPLE — rdf:li parseType="Resource" structs, Iptc4xmpCore struct,
+//                  kbrg: / stEvt: unknown-at-startup namespaces
+
+func Test_xmp_090(t *testing.T) {
+	data, err := os.ReadFile(testXMPBridge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(x.Items()); n != 42 {
+		t.Errorf("expected 42 items, got %d", n)
+	}
+	for _, it := range x.Items() {
+		t.Logf("kind=%-6s key=%-45s value=%q", it.ItemKind(), it.Key(), it.Value())
+	}
+}
+
+func Test_xmp_091(t *testing.T) {
+	// xmpMM:History must be a Seq of Struct items, not empty strings
+	data, err := os.ReadFile(testXMPBridge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hist := x.Get("xmpMM:History")
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 xmpMM:History, got %d", len(hist))
+	}
+	if hist[0].ItemKind() != xmp.Seq {
+		t.Errorf("xmpMM:History: expected Seq, got %s", hist[0].ItemKind())
+	}
+	entries := hist[0].Items()
+	if len(entries) != 2 {
+		t.Fatalf("xmpMM:History: expected 2 entries, got %d", len(entries))
+	}
+	for i, e := range entries {
+		if e.ItemKind() != xmp.Struct {
+			t.Errorf("entry %d: expected Struct, got %s", i, e.ItemKind())
+		}
+		if len(e.Items()) == 0 {
+			t.Errorf("entry %d: struct has no fields", i)
+		}
+		// Each struct should contain stEvt:action
+		found := false
+		for _, f := range e.Items() {
+			if f.Key() == "stEvt:action" {
+				found = true
+				t.Logf("entry %d stEvt:action=%q", i, f.Value())
+			}
+		}
+		if !found {
+			t.Errorf("entry %d: missing stEvt:action field", i)
+		}
+	}
+}
+
+func Test_xmp_092(t *testing.T) {
+	// Iptc4xmpCore:CreatorContactInfo must be a Struct with address fields
+	data, err := os.ReadFile(testXMPBridge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cci := x.Get("Iptc4xmpCore:CreatorContactInfo")
+	if len(cci) != 1 {
+		t.Fatalf("expected 1 CreatorContactInfo, got %d", len(cci))
+	}
+	if cci[0].ItemKind() != xmp.Struct {
+		t.Errorf("CreatorContactInfo: expected Struct, got %s", cci[0].ItemKind())
+	}
+	if n := len(cci[0].Items()); n != 8 {
+		t.Errorf("CreatorContactInfo: expected 8 fields, got %d", n)
+	}
+}
+
+func Test_xmp_093(t *testing.T) {
+	// Round-trip bridge file
+	data, err := os.ReadFile(testXMPBridge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := x.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+	x2, err := xmp.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("re-parse failed: %v\nencoded:\n%s", err, buf.String())
+	}
+	if got, want := len(x2.Items()), len(x.Items()); got != want {
+		t.Errorf("round-trip item count: got %d, want %d", got, want)
+	}
+}
+
+func Test_xmp_062(t *testing.T) {
+	// Round-trip the no-xpacket file
+	data, err := os.ReadFile(testXMPRandom)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x, err := xmp.Parse(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := x.Write(&buf); err != nil {
+		t.Fatal(err)
+	}
+	x2, err := xmp.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("re-parse failed: %v\nencoded:\n%s", err, buf.String())
+	}
+	if got, want := len(x2.Items()), len(x.Items()); got != want {
+		t.Errorf("round-trip item count: got %d, want %d", got, want)
+	}
+}

--- a/sys/libraw/image.go
+++ b/sys/libraw/image.go
@@ -1,0 +1,47 @@
+package libraw
+
+import "unsafe"
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libraw
+#include <stdlib.h>
+#include <libraw/libraw.h>
+*/
+import "C"
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - PROCESSED IMAGE
+
+func Libraw_dcraw_make_mem_image(data *Data) (*ProcessedImage, int) {
+	var errc C.int
+	img := C.libraw_dcraw_make_mem_image((*C.libraw_data_t)(data), &errc)
+	return (*ProcessedImage)(img), int(errc)
+}
+
+func Libraw_dcraw_make_mem_thumb(data *Data) (*ProcessedImage, int) {
+	var errc C.int
+	img := C.libraw_dcraw_make_mem_thumb((*C.libraw_data_t)(data), &errc)
+	return (*ProcessedImage)(img), int(errc)
+}
+
+func Libraw_dcraw_clear_mem(img *ProcessedImage) {
+	C.libraw_dcraw_clear_mem((*C.libraw_processed_image_t)(img))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - WRITE
+
+func Libraw_dcraw_ppm_tiff_writer(data *Data, filename string) int {
+	cfilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cfilename))
+	return int(C.libraw_dcraw_ppm_tiff_writer((*C.libraw_data_t)(data), cfilename))
+}
+
+func Libraw_dcraw_thumb_writer(data *Data, filename string) int {
+	cfilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cfilename))
+	return int(C.libraw_dcraw_thumb_writer((*C.libraw_data_t)(data), cfilename))
+}

--- a/sys/libraw/libraw.go
+++ b/sys/libraw/libraw.go
@@ -1,0 +1,240 @@
+package libraw
+
+import "unsafe"
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libraw
+#include <libraw/libraw.h>
+*/
+import "C"
+
+////////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+type (
+	Data            C.libraw_data_t
+	ProcessedImage  C.libraw_processed_image_t
+	IParams         C.libraw_iparams_t
+	ImageSizes      C.libraw_image_sizes_t
+	ImgOther        C.libraw_imgother_t
+	LensInfo        C.libraw_lensinfo_t
+	Thumbnail       C.libraw_thumbnail_t
+	ImageFormat     C.enum_LibRaw_image_formats
+	ThumbnailFormat C.enum_LibRaw_thumbnail_formats
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// GLOBALS
+
+const (
+	IMAGE_JPEG   ImageFormat = C.LIBRAW_IMAGE_JPEG
+	IMAGE_BITMAP ImageFormat = C.LIBRAW_IMAGE_BITMAP
+	IMAGE_JPEGXL ImageFormat = C.LIBRAW_IMAGE_JPEGXL
+
+	THUMBNAIL_UNKNOWN  ThumbnailFormat = C.LIBRAW_THUMBNAIL_UNKNOWN
+	THUMBNAIL_JPEG     ThumbnailFormat = C.LIBRAW_THUMBNAIL_JPEG
+	THUMBNAIL_BITMAP   ThumbnailFormat = C.LIBRAW_THUMBNAIL_BITMAP
+	THUMBNAIL_BITMAP16 ThumbnailFormat = C.LIBRAW_THUMBNAIL_BITMAP16
+	THUMBNAIL_H265     ThumbnailFormat = C.LIBRAW_THUMBNAIL_H265
+	THUMBNAIL_JPEGXL   ThumbnailFormat = C.LIBRAW_THUMBNAIL_JPEGXL
+)
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - LIFECYCLE
+
+func Libraw_init(flags uint) *Data {
+	return (*Data)(C.libraw_init(C.uint(flags)))
+}
+
+func Libraw_close(data *Data) {
+	C.libraw_close((*C.libraw_data_t)(data))
+}
+
+func Libraw_recycle(data *Data) {
+	C.libraw_recycle((*C.libraw_data_t)(data))
+}
+
+func Libraw_recycle_datastream(data *Data) {
+	C.libraw_recycle_datastream((*C.libraw_data_t)(data))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - INFO ACCESSORS
+
+func Libraw_get_iparams(data *Data) *IParams {
+	return (*IParams)(C.libraw_get_iparams((*C.libraw_data_t)(data)))
+}
+
+func Libraw_get_lensinfo(data *Data) *LensInfo {
+	return (*LensInfo)(C.libraw_get_lensinfo((*C.libraw_data_t)(data)))
+}
+
+func Libraw_get_imgother(data *Data) *ImgOther {
+	return (*ImgOther)(C.libraw_get_imgother((*C.libraw_data_t)(data)))
+}
+
+func Libraw_get_thumbnail(data *Data) *Thumbnail {
+	return (*Thumbnail)(&(*C.libraw_data_t)(data).thumbnail)
+}
+
+func Libraw_get_sizes(data *Data) *ImageSizes {
+	return (*ImageSizes)(&(*C.libraw_data_t)(data).sizes)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - DIMENSION GETTERS
+
+func Libraw_get_raw_height(data *Data) int {
+	return int(C.libraw_get_raw_height((*C.libraw_data_t)(data)))
+}
+
+func Libraw_get_raw_width(data *Data) int {
+	return int(C.libraw_get_raw_width((*C.libraw_data_t)(data)))
+}
+
+func Libraw_get_iheight(data *Data) int {
+	return int(C.libraw_get_iheight((*C.libraw_data_t)(data)))
+}
+
+func Libraw_get_iwidth(data *Data) int {
+	return int(C.libraw_get_iwidth((*C.libraw_data_t)(data)))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - IPARAMS FIELD ACCESSORS
+
+func IParams_make(p *IParams) string {
+	return C.GoString(&(*C.libraw_iparams_t)(p).make[0])
+}
+
+func IParams_model(p *IParams) string {
+	return C.GoString(&(*C.libraw_iparams_t)(p).model[0])
+}
+
+func IParams_software(p *IParams) string {
+	return C.GoString(&(*C.libraw_iparams_t)(p).software[0])
+}
+
+func IParams_normalized_make(p *IParams) string {
+	return C.GoString(&(*C.libraw_iparams_t)(p).normalized_make[0])
+}
+
+func IParams_normalized_model(p *IParams) string {
+	return C.GoString(&(*C.libraw_iparams_t)(p).normalized_model[0])
+}
+
+func IParams_raw_count(p *IParams) uint {
+	return uint((*C.libraw_iparams_t)(p).raw_count)
+}
+
+func IParams_colors(p *IParams) int {
+	return int((*C.libraw_iparams_t)(p).colors)
+}
+
+func IParams_filters(p *IParams) uint {
+	return uint((*C.libraw_iparams_t)(p).filters)
+}
+
+func IParams_xmpdata(p *IParams) []byte {
+	raw := (*C.libraw_iparams_t)(p)
+	if raw.xmpdata == nil || raw.xmplen == 0 {
+		return nil
+	}
+	return C.GoBytes(unsafe.Pointer(raw.xmpdata), C.int(raw.xmplen))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - IMGOTHER FIELD ACCESSORS
+
+func ImgOther_iso_speed(p *ImgOther) float32 {
+	return float32((*C.libraw_imgother_t)(p).iso_speed)
+}
+
+func ImgOther_shutter(p *ImgOther) float32 {
+	return float32((*C.libraw_imgother_t)(p).shutter)
+}
+
+func ImgOther_aperture(p *ImgOther) float32 {
+	return float32((*C.libraw_imgother_t)(p).aperture)
+}
+
+func ImgOther_focal_len(p *ImgOther) float32 {
+	return float32((*C.libraw_imgother_t)(p).focal_len)
+}
+
+func ImgOther_timestamp(p *ImgOther) int64 {
+	return int64((*C.libraw_imgother_t)(p).timestamp)
+}
+
+func ImgOther_shot_order(p *ImgOther) uint {
+	return uint((*C.libraw_imgother_t)(p).shot_order)
+}
+
+func ImgOther_desc(p *ImgOther) string {
+	return C.GoString(&(*C.libraw_imgother_t)(p).desc[0])
+}
+
+func ImgOther_artist(p *ImgOther) string {
+	return C.GoString(&(*C.libraw_imgother_t)(p).artist[0])
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - THUMBNAIL FIELD ACCESSORS
+
+func Thumbnail_format(t *Thumbnail) ThumbnailFormat {
+	return ThumbnailFormat((*C.libraw_thumbnail_t)(t).tformat)
+}
+
+func Thumbnail_width(t *Thumbnail) uint16 {
+	return uint16((*C.libraw_thumbnail_t)(t).twidth)
+}
+
+func Thumbnail_height(t *Thumbnail) uint16 {
+	return uint16((*C.libraw_thumbnail_t)(t).theight)
+}
+
+func Thumbnail_length(t *Thumbnail) uint {
+	return uint((*C.libraw_thumbnail_t)(t).tlength)
+}
+
+func Thumbnail_data(t *Thumbnail) []byte {
+	raw := (*C.libraw_thumbnail_t)(t)
+	if raw.thumb == nil || raw.tlength == 0 {
+		return nil
+	}
+	return C.GoBytes(unsafe.Pointer(raw.thumb), C.int(raw.tlength))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - PROCESSED IMAGE FIELD ACCESSORS
+
+func ProcessedImage_type(img *ProcessedImage) ImageFormat {
+	return ImageFormat((*C.libraw_processed_image_t)(img)._type)
+}
+
+func ProcessedImage_height(img *ProcessedImage) uint16 {
+	return uint16((*C.libraw_processed_image_t)(img).height)
+}
+
+func ProcessedImage_width(img *ProcessedImage) uint16 {
+	return uint16((*C.libraw_processed_image_t)(img).width)
+}
+
+func ProcessedImage_colors(img *ProcessedImage) uint16 {
+	return uint16((*C.libraw_processed_image_t)(img).colors)
+}
+
+func ProcessedImage_bits(img *ProcessedImage) uint16 {
+	return uint16((*C.libraw_processed_image_t)(img).bits)
+}
+
+func ProcessedImage_data(img *ProcessedImage) []byte {
+	raw := (*C.libraw_processed_image_t)(img)
+	if raw.data_size == 0 {
+		return nil
+	}
+	return C.GoBytes(unsafe.Pointer(&raw.data[0]), C.int(raw.data_size))
+}

--- a/sys/libraw/libraw_test.go
+++ b/sys/libraw/libraw_test.go
@@ -1,0 +1,5 @@
+package libraw_test
+
+const (
+	testRAW = "../../etc/test/RAW_OLYMPUS_E3.ORF"
+)

--- a/sys/libraw/open.go
+++ b/sys/libraw/open.go
@@ -1,0 +1,26 @@
+package libraw
+
+import "unsafe"
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libraw
+#include <stdlib.h>
+#include <libraw/libraw.h>
+*/
+import "C"
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - OPEN
+
+func Libraw_open_file(data *Data, filename string) int {
+	cfilename := C.CString(filename)
+	defer C.free(unsafe.Pointer(cfilename))
+	return int(C.libraw_open_file((*C.libraw_data_t)(data), cfilename))
+}
+
+func Libraw_open_buffer(data *Data, buf []byte) int {
+	return int(C.libraw_open_buffer((*C.libraw_data_t)(data), unsafe.Pointer(&buf[0]), C.size_t(len(buf))))
+}

--- a/sys/libraw/open_test.go
+++ b/sys/libraw/open_test.go
@@ -1,0 +1,164 @@
+package libraw_test
+
+import (
+	"os"
+	"testing"
+
+	// Namespace imports
+	. "github.com/mutablelogic/go-media/sys/libraw"
+)
+
+func Test_open_000(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+}
+
+func Test_open_001(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+}
+
+func Test_open_002(t *testing.T) {
+	buf, err := os.ReadFile(testRAW)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_buffer(data, buf); rc != 0 {
+		t.Fatalf("Libraw_open_buffer: %v", Libraw_strerror(rc))
+	}
+}
+
+func Test_open_003(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+
+	p := Libraw_get_iparams(data)
+	if p == nil {
+		t.Fatal("Libraw_get_iparams returned nil")
+	}
+	t.Logf("make=%q model=%q raw_count=%d colors=%d",
+		IParams_make(p), IParams_model(p), IParams_raw_count(p), IParams_colors(p))
+
+	if IParams_make(p) == "" {
+		t.Error("expected non-empty camera make")
+	}
+	if IParams_model(p) == "" {
+		t.Error("expected non-empty camera model")
+	}
+}
+
+func Test_open_004(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+
+	other := Libraw_get_imgother(data)
+	if other == nil {
+		t.Fatal("Libraw_get_imgother returned nil")
+	}
+	t.Logf("iso_speed=%.0f shutter=%.6f aperture=%.1f focal_len=%.1f timestamp=%d",
+		ImgOther_iso_speed(other), ImgOther_shutter(other),
+		ImgOther_aperture(other), ImgOther_focal_len(other),
+		ImgOther_timestamp(other))
+}
+
+func Test_open_005(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+
+	w := Libraw_get_raw_width(data)
+	h := Libraw_get_raw_height(data)
+	iw := Libraw_get_iwidth(data)
+	ih := Libraw_get_iheight(data)
+	t.Logf("raw=%dx%d image=%dx%d", w, h, iw, ih)
+
+	if w == 0 || h == 0 {
+		t.Error("expected non-zero raw dimensions")
+	}
+}
+
+func Test_open_006(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+
+	sizes := Libraw_get_sizes(data)
+	if sizes == nil {
+		t.Fatal("Libraw_get_sizes returned nil")
+	}
+}
+
+func Test_open_007(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+
+	lens := Libraw_get_lensinfo(data)
+	if lens == nil {
+		t.Fatal("Libraw_get_lensinfo returned nil")
+	}
+}
+
+func Test_open_008(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+
+	Libraw_recycle_datastream(data)
+	Libraw_recycle(data)
+}

--- a/sys/libraw/params.go
+++ b/sys/libraw/params.go
@@ -1,0 +1,76 @@
+package libraw
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libraw
+#include <libraw/libraw.h>
+*/
+import "C"
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - OUTPUT PARAM SETTERS
+
+func Libraw_set_demosaic(data *Data, value int) {
+	C.libraw_set_demosaic((*C.libraw_data_t)(data), C.int(value))
+}
+
+func Libraw_set_output_color(data *Data, value int) {
+	C.libraw_set_output_color((*C.libraw_data_t)(data), C.int(value))
+}
+
+func Libraw_set_output_bps(data *Data, value int) {
+	C.libraw_set_output_bps((*C.libraw_data_t)(data), C.int(value))
+}
+
+func Libraw_set_output_tif(data *Data, value int) {
+	C.libraw_set_output_tif((*C.libraw_data_t)(data), C.int(value))
+}
+
+func Libraw_set_no_auto_bright(data *Data, value int) {
+	C.libraw_set_no_auto_bright((*C.libraw_data_t)(data), C.int(value))
+}
+
+func Libraw_set_bright(data *Data, value float32) {
+	C.libraw_set_bright((*C.libraw_data_t)(data), C.float(value))
+}
+
+func Libraw_set_highlight(data *Data, value int) {
+	C.libraw_set_highlight((*C.libraw_data_t)(data), C.int(value))
+}
+
+func Libraw_set_gamma(data *Data, index int, value float32) {
+	C.libraw_set_gamma((*C.libraw_data_t)(data), C.int(index), C.float(value))
+}
+
+func Libraw_set_user_mul(data *Data, index int, value float32) {
+	C.libraw_set_user_mul((*C.libraw_data_t)(data), C.int(index), C.float(value))
+}
+
+func Libraw_set_adjust_maximum_thr(data *Data, value float32) {
+	C.libraw_set_adjust_maximum_thr((*C.libraw_data_t)(data), C.float(value))
+}
+
+func Libraw_set_fbdd_noiserd(data *Data, value int) {
+	C.libraw_set_fbdd_noiserd((*C.libraw_data_t)(data), C.int(value))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - COLOR GETTERS
+
+func Libraw_get_cam_mul(data *Data, index int) float32 {
+	return float32(C.libraw_get_cam_mul((*C.libraw_data_t)(data), C.int(index)))
+}
+
+func Libraw_get_pre_mul(data *Data, index int) float32 {
+	return float32(C.libraw_get_pre_mul((*C.libraw_data_t)(data), C.int(index)))
+}
+
+func Libraw_get_rgb_cam(data *Data, index1, index2 int) float32 {
+	return float32(C.libraw_get_rgb_cam((*C.libraw_data_t)(data), C.int(index1), C.int(index2)))
+}
+
+func Libraw_get_color_maximum(data *Data) int {
+	return int(C.libraw_get_color_maximum((*C.libraw_data_t)(data)))
+}

--- a/sys/libraw/process.go
+++ b/sys/libraw/process.go
@@ -1,0 +1,48 @@
+package libraw
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libraw
+#include <libraw/libraw.h>
+*/
+import "C"
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - UNPACK
+
+func Libraw_unpack(data *Data) int {
+	return int(C.libraw_unpack((*C.libraw_data_t)(data)))
+}
+
+func Libraw_unpack_thumb(data *Data) int {
+	return int(C.libraw_unpack_thumb((*C.libraw_data_t)(data)))
+}
+
+func Libraw_unpack_thumb_ex(data *Data, i int) int {
+	return int(C.libraw_unpack_thumb_ex((*C.libraw_data_t)(data), C.int(i)))
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - PROCESS
+
+func Libraw_dcraw_process(data *Data) int {
+	return int(C.libraw_dcraw_process((*C.libraw_data_t)(data)))
+}
+
+func Libraw_raw2image(data *Data) int {
+	return int(C.libraw_raw2image((*C.libraw_data_t)(data)))
+}
+
+func Libraw_free_image(data *Data) {
+	C.libraw_free_image((*C.libraw_data_t)(data))
+}
+
+func Libraw_adjust_sizes_info_only(data *Data) int {
+	return int(C.libraw_adjust_sizes_info_only((*C.libraw_data_t)(data)))
+}
+
+func Libraw_subtract_black(data *Data) {
+	C.libraw_subtract_black((*C.libraw_data_t)(data))
+}

--- a/sys/libraw/process_test.go
+++ b/sys/libraw/process_test.go
@@ -1,0 +1,122 @@
+package libraw_test
+
+import (
+	"testing"
+
+	// Namespace imports
+	. "github.com/mutablelogic/go-media/sys/libraw"
+)
+
+func Test_process_000(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_unpack_thumb(data); rc != 0 {
+		t.Fatalf("Libraw_unpack_thumb: %v", Libraw_strerror(rc))
+	}
+
+	thumb := Libraw_get_thumbnail(data)
+	if thumb == nil {
+		t.Fatal("Libraw_get_thumbnail returned nil")
+	}
+	t.Logf("thumbnail format=%v size=%dx%d length=%d",
+		Thumbnail_format(thumb), Thumbnail_width(thumb), Thumbnail_height(thumb), Thumbnail_length(thumb))
+
+	if Thumbnail_length(thumb) == 0 {
+		t.Error("expected non-zero thumbnail length")
+	}
+	if len(Thumbnail_data(thumb)) == 0 {
+		t.Error("expected non-empty thumbnail data")
+	}
+}
+
+func Test_process_001(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_unpack(data); rc != 0 {
+		t.Fatalf("Libraw_unpack: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_dcraw_process(data); rc != 0 {
+		t.Fatalf("Libraw_dcraw_process: %v", Libraw_strerror(rc))
+	}
+}
+
+func Test_process_002(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_unpack(data); rc != 0 {
+		t.Fatalf("Libraw_unpack: %v", Libraw_strerror(rc))
+	}
+
+	Libraw_subtract_black(data)
+
+	if rc := Libraw_raw2image(data); rc != 0 {
+		t.Fatalf("Libraw_raw2image: %v", Libraw_strerror(rc))
+	}
+	Libraw_free_image(data)
+}
+
+func Test_process_003(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_adjust_sizes_info_only(data); rc != 0 {
+		t.Fatalf("Libraw_adjust_sizes_info_only: %v", Libraw_strerror(rc))
+	}
+
+	w := Libraw_get_iwidth(data)
+	h := Libraw_get_iheight(data)
+	t.Logf("adjusted image size=%dx%d", w, h)
+}
+
+func Test_process_004(t *testing.T) {
+	data := Libraw_init(0)
+	if data == nil {
+		t.Fatal("Libraw_init returned nil")
+	}
+	defer Libraw_close(data)
+
+	if rc := Libraw_open_file(data, testRAW); rc != 0 {
+		t.Fatalf("Libraw_open_file: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_unpack(data); rc != 0 {
+		t.Fatalf("Libraw_unpack: %v", Libraw_strerror(rc))
+	}
+	if rc := Libraw_dcraw_process(data); rc != 0 {
+		t.Fatalf("Libraw_dcraw_process: %v", Libraw_strerror(rc))
+	}
+
+	t.Logf("cam_mul=[%.4f %.4f %.4f %.4f]",
+		Libraw_get_cam_mul(data, 0), Libraw_get_cam_mul(data, 1),
+		Libraw_get_cam_mul(data, 2), Libraw_get_cam_mul(data, 3))
+	t.Logf("pre_mul=[%.4f %.4f %.4f %.4f]",
+		Libraw_get_pre_mul(data, 0), Libraw_get_pre_mul(data, 1),
+		Libraw_get_pre_mul(data, 2), Libraw_get_pre_mul(data, 3))
+	t.Logf("color_maximum=%d", Libraw_get_color_maximum(data))
+}

--- a/sys/libraw/version.go
+++ b/sys/libraw/version.go
@@ -1,0 +1,51 @@
+package libraw
+
+////////////////////////////////////////////////////////////////////////////////
+// CGO
+
+/*
+#cgo pkg-config: libraw
+#include <libraw/libraw.h>
+*/
+import "C"
+
+import "unsafe"
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - VERSION
+
+func Libraw_version() string {
+	return C.GoString(C.libraw_version())
+}
+
+func Libraw_versionNumber() int {
+	return int(C.libraw_versionNumber())
+}
+
+func Libraw_capabilities() uint {
+	return uint(C.libraw_capabilities())
+}
+
+func Libraw_cameraCount() int {
+	return int(C.libraw_cameraCount())
+}
+
+func Libraw_cameraList() []string {
+	list := C.libraw_cameraList()
+	count := Libraw_cameraCount()
+	if list == nil || count == 0 {
+		return nil
+	}
+	result := make([]string, count)
+	for i := 0; i < count; i++ {
+		result[i] = C.GoString(*(**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(list)) + uintptr(i)*unsafe.Sizeof(*list))))
+	}
+	return result
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// BINDINGS - ERROR
+
+func Libraw_strerror(errcode int) string {
+	return C.GoString(C.libraw_strerror(C.int(errcode)))
+}

--- a/sys/libraw/version_test.go
+++ b/sys/libraw/version_test.go
@@ -1,0 +1,50 @@
+package libraw_test
+
+import (
+	"testing"
+
+	// Namespace imports
+	. "github.com/mutablelogic/go-media/sys/libraw"
+)
+
+func Test_version_000(t *testing.T) {
+	v := Libraw_version()
+	if v == "" {
+		t.Fatal("Libraw_version returned empty string")
+	}
+	t.Log("version=", v)
+}
+
+func Test_version_001(t *testing.T) {
+	n := Libraw_versionNumber()
+	if n == 0 {
+		t.Fatal("Libraw_versionNumber returned 0")
+	}
+	t.Log("versionNumber=", n)
+}
+
+func Test_version_002(t *testing.T) {
+	caps := Libraw_capabilities()
+	t.Logf("capabilities=0x%x", caps)
+}
+
+func Test_version_003(t *testing.T) {
+	n := Libraw_cameraCount()
+	if n == 0 {
+		t.Fatal("Libraw_cameraCount returned 0")
+	}
+	t.Log("cameraCount=", n)
+}
+
+func Test_version_004(t *testing.T) {
+	list := Libraw_cameraList()
+	if len(list) == 0 {
+		t.Fatal("Libraw_cameraList returned empty list")
+	}
+	t.Logf("cameraList[0]=%q count=%d", list[0], len(list))
+}
+
+func Test_version_005(t *testing.T) {
+	msg := Libraw_strerror(0)
+	t.Log("strerror(0)=", msg)
+}


### PR DESCRIPTION
This pull request introduces support for building and testing the `libraw` library and adds several XMP metadata test files. It also improves the `pkg/exif` API to provide XMP-compatible tag keys, making metadata lookup consistent between EXIF and XMP sources. The most important changes are as follows:

**Build system: libraw integration**
- Added build, configure, and install rules for `libraw` to the `Makefile`, including version management and patching for DNG support. The build process now downloads, configures, and installs `libraw` alongside other dependencies. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L15-R16) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R149-R202)
- Added `test-raw` target to the `Makefile` to run Go tests for both `sys/libraw` and `pkg/raw`, and included this in the main `test` target. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L204-R240) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R256-R261)

**EXIF/XMP API improvements**
- Updated the `Tag.Key()` method in `pkg/exif/tag.go` to return XMP-compatible keys: tags from IFD0/IFD1 are prefixed with `tiff:`, and EXIF/GPS/Interop tags with `exif:`. This aligns with XMP namespace conventions for more consistent cross-source metadata lookups.

**Test data additions**
- Added several XMP metadata example files under `etc/test/` for use in testing XMP parsing and interoperability:
  - [`sample.xmp`](diffhunk://#diff-481897a5abf68779fad4addf38da8a01333496e88ad70d0c7c226965d0af23f3R1-R38): a simple XMP metadata sample
  - [`random-xmp-example.xmp`](diffhunk://#diff-1c99ecde3ac03ddac0a7b21f08bf1264a9e66bd65510e4be304017054e911712R1-R47): a random PDF XMP metadata example
  - [`pdfx-xmp-example.xmp`](diffhunk://#diff-5895fc38f18f002c84496a65f3063785f846efb9c6f062040787de410e014ca0R1-R118): a real-world PDF XMP metadata example
  - [`bridge-2.xmp`](diffhunk://#diff-6db353aac50cb5c0e03926ba4bf24531ad0eb9af2ccfacdb4ea864aeac18b65fR1-R147): a complex XMP metadata sample as exported by Adobe Bridge

**Other improvements**
- Simplified and standardized the version variable for `libexif` in the `Makefile` to match the naming convention used for other dependencies. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L15-R16) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R149-R202)
- Refactored the `Makefile` rules for downloading and building `libexif` to use the new version variable and consistent directory structure.

These changes together improve metadata support and interoperability, expand test coverage, and make the build system more robust.