### PR TITLE
Update FFmpeg to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ JOBS ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 # Source version
 #FFMPEG_VERSION ?= ffmpeg-7.1.1
 #SYS_VERSION ?= ffmpeg71
-FFMPEG_VERSION ?= ffmpeg-8.0.1
+FFMPEG_VERSION ?= ffmpeg-8.0.3
 SYS_VERSION ?= ffmpeg80
 CHROMAPRINT_VERSION ?= chromaprint-1.5.1
 LIBEXIF_VERSION ?= 0.6.26

--- a/NOTICE
+++ b/NOTICE
@@ -15,8 +15,8 @@ FFmpeg Copyright Notice:
 
 The complete FFmpeg source code used in this build is available at:
 
-- <https://ffmpeg.org/releases/ffmpeg-8.0.1.tar.xz>
-- Or in the build/ffmpeg-8.0.1/ directory after running `make`
+- <https://ffmpeg.org/releases/ffmpeg-8.0.3.tar.xz>
+- Or in the build/ffmpeg-8.0.3/ directory after running `make`
 
 The LGPL license for FFmpeg is available at:
   <http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html>

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This software statically links to [FFmpeg](http://ffmpeg.org/) libraries, which 
 **Requirements when distributing binaries:**
 
 1. Include this notice and the FFmpeg LGPL license
-2. Provide access to the FFmpeg source code used (available at `build/ffmpeg-8.0.1/` after building)
+2. Provide access to the FFmpeg source code used (available at `build/ffmpeg-8.0.3/` after building)
 3. Allow users to relink the application with modified FFmpeg libraries
 
 The FFmpeg source code is automatically downloaded during the build process. See `Makefile` for details.


### PR DESCRIPTION
This pull request updates the FFmpeg version used in the `Makefile` to ensure the project builds with the latest patch release.

Dependency version update:

* Updated `FFMPEG_VERSION` in `Makefile` from `ffmpeg-8.0.1` to `ffmpeg-8.0.3` to use the latest available version.