### PR TITLE
Added AVSEEK_SIZE support

### DIFF
--- a/pkg/ffmpeg/reader.go
+++ b/pkg/ffmpeg/reader.go
@@ -331,6 +331,9 @@ func (r *Reader) Demux(ctx context.Context, mapfn DecoderMapFunc, framefn Decode
 
 func (r *reader_callback) Reader(buf []byte) int {
 	n, err := r.r.Read(buf)
+	if n > 0 {
+		return n
+	}
 	if err != nil {
 		return ff.AVERROR_EOF
 	}
@@ -342,6 +345,20 @@ func (r *reader_callback) Seeker(offset int64, whence int) int64 {
 	seeker, ok := r.r.(io.ReadSeeker)
 	if !ok {
 		return -1
+	}
+	if whence == ff.AVSEEK_SIZE {
+		current, err := seeker.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return -1
+		}
+		size, err := seeker.Seek(0, io.SeekEnd)
+		if err != nil {
+			return -1
+		}
+		if _, err := seeker.Seek(current, io.SeekStart); err != nil {
+			return -1
+		}
+		return size
 	}
 	switch whence {
 	case io.SeekStart, io.SeekCurrent, io.SeekEnd:

--- a/pkg/ffmpeg/reader_test.go
+++ b/pkg/ffmpeg/reader_test.go
@@ -1,18 +1,59 @@
 package ffmpeg
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	// Packages
 	media "github.com/mutablelogic/go-media"
+	ff "github.com/mutablelogic/go-media/sys/ffmpeg80"
 	assert "github.com/stretchr/testify/assert"
 )
 
 const (
 	testDir = "../../etc/test"
 )
+
+type eofAfterBytesReader struct {
+	data []byte
+}
+
+func (r *eofAfterBytesReader) Read(buf []byte) (int, error) {
+	n := copy(buf, r.data)
+	r.data = r.data[n:]
+	if n > 0 {
+		return n, io.EOF
+	}
+	return 0, io.EOF
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// TEST READER CALLBACK
+
+func Test_reader_callback_reader_returns_bytes_before_eof(t *testing.T) {
+	assert := assert.New(t)
+	callback := reader_callback{r: &eofAfterBytesReader{data: []byte("abc")}}
+
+	buf := make([]byte, 8)
+	assert.Equal(3, callback.Reader(buf))
+	assert.Equal([]byte("abc"), buf[:3])
+	assert.Equal(ff.AVERROR_EOF, callback.Reader(buf))
+}
+
+func Test_reader_callback_seeker_size(t *testing.T) {
+	assert := assert.New(t)
+	reader := bytes.NewReader([]byte("abcdef"))
+	callback := reader_callback{r: reader}
+
+	assert.Equal(int64(2), callback.Seeker(2, io.SeekStart))
+	assert.Equal(int64(6), callback.Seeker(0, ff.AVSEEK_SIZE))
+	pos, err := reader.Seek(0, io.SeekCurrent)
+	assert.NoError(err)
+	assert.Equal(int64(2), pos)
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // TEST OPEN FROM FILE PATH


### PR DESCRIPTION
This pull request enhances the `reader_callback` implementation in the `ffmpeg` package by improving how end-of-file (EOF) and stream size are handled, and adds targeted unit tests to verify these behaviors. The changes increase compatibility with FFmpeg's expectations and improve robustness.

### Reader and Seeker Behavior Improvements

* Modified the `Reader` method in `reader_callback` to immediately return the number of bytes read if any bytes are available, even if an EOF is encountered, ensuring partial reads are handled correctly.
* Enhanced the `Seeker` method in `reader_callback` to properly handle the `AVSEEK_SIZE` operation by seeking to the end to determine stream size, then restoring the original position.

### Testing Enhancements

* Added `eofAfterBytesReader` test helper and comprehensive unit tests in `reader_test.go` to verify that `Reader` returns bytes before EOF and that `Seeker` correctly reports the stream size and maintains position.