### PR TITLE
Added docker dependencies to build

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x && apt update -y \
   && apt install -y ca-certificates lsb-release \
   && apt install -y libfreetype6 libmp3lame0 libopus0 libvorbis0a libvorbisenc2 libvpx9 libx264-164 libx265-215 libnuma1 \
   && apt install -y libvulkan1 vulkan-tools \
-  && apt install -y libde265-0 libaom3 libdav1d7
+  && apt install -y libde265-0 libaom3 libdav1d7 libgomp1
 
 COPY --from=builder /usr/src/app/build/* /usr/local/bin/
 


### PR DESCRIPTION
This pull request makes a small update to the Docker build process by adding a missing dependency to the list of installed packages. This helps ensure the application has all required libraries at runtime.

Dependency updates:

* Added the `libgomp1` package to the `apt install` command in `etc/docker/Dockerfile` to provide OpenMP support, which may be required by certain libraries or application components.